### PR TITLE
Fixed forcing object type error, added climatology shellscript, updated readmes

### DIFF
--- a/forcing/trapsF00/make_LOriv_forcing.py
+++ b/forcing/trapsF00/make_LOriv_forcing.py
@@ -125,7 +125,7 @@ def make_forcing(N,NT,dt_ind,yd_ind,ot_vec,dt1,days,Ldir,trapsP,trapsD):
         vinfo = zrfun.get_varinfo(vn, vartype='climatology')
         # get river direction (idir)
         if vn == 'river_direction':
-            LOriv_ds[vn] = (('river',), gri_df.idir.to_numpy())
+            LOriv_ds[vn] = (('river',), gri_df.idir.to_numpy().astype(int))
         # Add X-position (column index on v-grid)
         elif vn == 'river_Xposition':
             X_vec = np.nan * np.ones(NRIV)

--- a/forcing/trapsF00/make_triv_forcing.py
+++ b/forcing/trapsF00/make_triv_forcing.py
@@ -131,7 +131,7 @@ def make_forcing(N,NT,NRIV,dt_ind, yd_ind,ot_vec,Ldir,enable,trapsP, trapsD):
             vinfo = zrfun.get_varinfo(vn, vartype='climatology')
             # get river direction (idir)
             if vn == 'river_direction':
-                triv_ds[vn] = (('river',), gri_df_no_ovrlp.idir.to_numpy())
+                triv_ds[vn] = (('river',), gri_df_no_ovrlp.idir.to_numpy().astype(int))
             # Add X-position (column index on u-grid)
             elif vn == 'river_Xposition':
                 X_vec = np.nan * np.ones(NTRIV)

--- a/forcing/trapsF01/make_LOriv_forcing.py
+++ b/forcing/trapsF01/make_LOriv_forcing.py
@@ -125,7 +125,7 @@ def make_forcing(N,NT,dt_ind,yd_ind,ot_vec,dt1,days,Ldir,trapsP,trapsD):
         vinfo = zrfun.get_varinfo(vn, vartype='climatology')
         # get river direction (idir)
         if vn == 'river_direction':
-            LOriv_ds[vn] = (('river',), gri_df.idir.to_numpy())
+            LOriv_ds[vn] = (('river',), gri_df.idir.to_numpy().astype(int))
         # Add X-position (column index on v-grid)
         elif vn == 'river_Xposition':
             X_vec = np.nan * np.ones(NRIV)

--- a/forcing/trapsF01/make_triv_forcing.py
+++ b/forcing/trapsF01/make_triv_forcing.py
@@ -131,7 +131,7 @@ def make_forcing(N,NT,NRIV,dt_ind, yd_ind,ot_vec,Ldir,enable,trapsP, trapsD):
             vinfo = zrfun.get_varinfo(vn, vartype='climatology')
             # get river direction (idir)
             if vn == 'river_direction':
-                triv_ds[vn] = (('river',), gri_df_no_ovrlp.idir.to_numpy())
+                triv_ds[vn] = (('river',), gri_df_no_ovrlp.idir.to_numpy().astype(int))
             # Add X-position (column index on u-grid)
             elif vn == 'river_Xposition':
                 X_vec = np.nan * np.ones(NTRIV)

--- a/pre/trapsP00/README.md
+++ b/pre/trapsP00/README.md
@@ -1,3 +1,5 @@
 # LO/pre/trapsP##
 
-Please see user notes in the traps_notes directory [here](https://github.com/parkermac/LO/tree/main/traps_notes/pre_notes).
+It is recommended that users should run the climatology scripts on the machine in which they woud like to generate forcing. For instance, if you want to generate TRAPS forcing on perigee, run these scripts on perigee.
+
+For more details, please see user notes in the traps_notes directory [here](https://github.com/parkermac/LO/tree/main/traps_notes/pre_notes).

--- a/pre/trapsP00/climatology_all_source_types.sh
+++ b/pre/trapsP00/climatology_all_source_types.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+python ./make_climatology_tinyrivs.py
+python ./make_climatology_pointsources.py
+python ./make_climatology_LOrivbio.py

--- a/pre/trapsP00/ecology_excel2netCDF.py
+++ b/pre/trapsP00/ecology_excel2netCDF.py
@@ -13,7 +13,7 @@ Then, the netCDF files can be referenced to generate climatologies
 Takes about 5-8 minutes to run on my local machine.
 
 To run from ipython:
-run ecology_excel2xarray.py
+run ecology_excel2netCDF.py
 """
 
 #################################################################################

--- a/pre/trapsP00/make_climatology_LOrivbio.py
+++ b/pre/trapsP00/make_climatology_LOrivbio.py
@@ -113,7 +113,7 @@ yrday = pd.date_range(start ='1/1/2020', end ='12/31/2020', freq ='D')
 #                          Calculate climatologies                              #
 #################################################################################
 
-print('Calculating climatologies...')
+print('Calculating pre-existing LO river climatologies...')
 
 # loop through all nonpoint sources
 for i,rname in enumerate(LOrivnames_realisticBGC):
@@ -209,7 +209,7 @@ figname = 'LOrivbio_river_summary.png'
 save_path = clim_dir / figname
 fig.savefig(save_path)
 
-print('Climatologies done\n')
+print('Pre-existing LO river climatologies done\n')
 
 #################################################################################
 #                    Plot all individual river climatologies                    #

--- a/pre/trapsP00/make_climatology_pointsources.py
+++ b/pre/trapsP00/make_climatology_pointsources.py
@@ -99,7 +99,7 @@ yrday = pd.date_range(start ='1/1/2020', end ='12/31/2020', freq ='D')
 #                          Calculate climatologies                              #
 #################################################################################
 
-print('Calculating climatologies...')
+print('Calculating point source climatologies...')
 
 # loop through all point sources
 for i,wname in enumerate(wwtpnames):
@@ -195,7 +195,7 @@ figname = 'point_source_summary.png'
 save_path = clim_dir / figname
 fig.savefig(save_path)
 
-print('Climatologies done\n')
+print('Point source climatologies done\n')
 
 #################################################################################
 #              Plot all individual point source climatologies                   #

--- a/pre/trapsP00/make_climatology_tinyrivs.py
+++ b/pre/trapsP00/make_climatology_tinyrivs.py
@@ -139,7 +139,7 @@ for riv in shifted:
 #                          Calculate climatologies                              #
 #################################################################################
 
-print('Calculating climatologies...')
+print('Calculating tiny river climatologies...')
 
 # loop through all nonpoint sources
 for i,rname in enumerate(trivnames):
@@ -291,7 +291,7 @@ for rname in weird_DO_and_NH4:
     NH4_clim_df[rname]  = clim_avgs['NH4(mmol/m3)']     # [mmol/m3]
     DO_clim_df[rname]   = clim_avgs['DO(mmol/m3)']      # [mmol/m3]
 
-print('Climatologies done\n')
+print('Tiny river climatologies done\n')
 
 #################################################################################
 #                Plot all individual tiny river climatologies                   #

--- a/traps_notes/README.md
+++ b/traps_notes/README.md
@@ -66,7 +66,7 @@ Note that currently, only trapsD00 is available for use. However, this config fi
 
 <details><summary>1.5. Convert raw Ecology data from excel file to netCDF</summary>
     
-*Note: User does not need to run this step. It is listed here for completion. During TRAPS development and testing, the developer already ran this script. Users can skip to step 2.*
+*Note: User does not need to run this step. It is listed here for completion. During TRAPS development and testing, the developer already ran this script. Users can skip to step 2. However, if the user decides to run this script, it is advised that they run it on their remote machine (or wherever they plan to generate forcing).*
 
 This step runs one script which consolidates all of Ecology's raw data (in excel format) into netCDF files with daily resolution from Jan 1999 - Jul 2017.
 
@@ -77,7 +77,7 @@ These new files are all_nonpoint_source_data.nc and all_point_source_data.nc sto
 <details><summary>2. Generate climatologies</summary>
     
 This step generates climatology files for each of the TRAPS.
-From your remote machine in LO/pre/trapsP## in ipython:
+From your **remote machine** (or whichever machine you will use to generate forcing) in LO/pre/trapsP## in ipython:
 
 ```
 run make_climatology_tinyrivs.py

--- a/traps_notes/README.md
+++ b/traps_notes/README.md
@@ -50,7 +50,7 @@ After getting the required files, users should be able to add TRAPS to their mod
 
 <details><summary><strong>TRAPS workflow diagram</strong></summary>
 
-![traps-top-level-diagram-v6](https://github.com/ajleeson/LO_user/assets/15829099/25faac21-59fd-4b3a-9ec4-2db46a8ef6cc)
+![traps-top-level-diagram-v7](https://github.com/ajleeson/LO_user/assets/15829099/c8534744-5240-476e-807d-7c7d44793a1f)
 
 </details>
 
@@ -77,13 +77,12 @@ These new files are all_nonpoint_source_data.nc and all_point_source_data.nc sto
 <details><summary>2. Generate climatologies</summary>
     
 This step generates climatology files for each of the TRAPS.
-From your **remote machine** (or whichever machine you will use to generate forcing) in LO/pre/trapsP## in ipython:
+From your **remote machine** (or whichever machine you will use to generate forcing) in LO/pre/trapsP##:
 
 ```
-run make_climatology_tinyrivs.py
-run make_climatology_pointsources.py
-run make_climatology_LOrivbio.py
+bash climatology_all_source_types.sh
 ```
+This shellscript runs climatology scripts for all source types (tiny rivers, pre-existing LiveOcean rivers, and point sources).
 
 Climatology pickle files will be generated and saved in three folders in LO_output/pre/trapsP##:
 
@@ -91,7 +90,15 @@ Climatology pickle files will be generated and saved in three folders in LO_outp
 - **tiny_rivers:** Climatology files for tiny rivers
 - **LO_rivbio:** Climatology files for pre-existing LO rivers
   
-If you want to look at climatology timeseries, run with ```-test True``` on your local machine. This option will create a subfolder in LO_output/pre/trapsP##/[source type]/lo_base/Data_historical/climatology_plots with a climatology figure for each source. An example figure for Burley Creek is shown below.
+If you want to look at timeseries figures of the climatologies, then run the following commands **on your local machine** from LO/pre/trapsP### in ipython:
+
+```
+run make_climatology_tinyrivs.py -test True
+run make_climatology_pointsources.py -test True
+run make_climatology_LOrivbio.py -test True
+```
+
+The "test" option will create a subfolder in LO_output/pre/trapsP##/[source type]/lo_base/Data_historical/climatology_plots with a climatology figure for each source. An example figure for Burley Creek is shown below.
 
 ![Burley Cr](https://github.com/ajleeson/LO_user/assets/15829099/adc0456f-f855-4428-82c5-63f5aa1fa5b0)
 
@@ -199,6 +206,20 @@ And also in LO/pre/trapsV##/traps_placement.py:
 
 ---
 ## Update Notes
+
+<details><summary><strong>2024.03.01 update</strong></summary>
+
+**Fixed object type error and added climatology shellscript**
+
+This update fixes a user-reported bug in the TRAPS forcing generation step. Previously, the object type for river_direction was inconsistent between tiny rivers and pre-existing LO rivers, which caused an error. Now, river_direction is defined as an int for both tiny rivers and pre-existing rivers, resolving the incompatible-type issue.
+
+Additionally, I have added a shellscript in LO/pre/trapsP## called climatology_all_source_types.sh. This new script automates the climatology generation process so users no longer need to separately generate climatology for point sources, tiny rivers, and pre-existing LO rivers.
+
+READMEs have been updated to reflect code changes.
+
+Thanks to Parker for providing user feedback.
+
+</details>
 
 <details><summary><strong>2023.12.22 update</strong></summary>
 

--- a/traps_notes/pre_notes/README.md
+++ b/traps_notes/pre_notes/README.md
@@ -17,6 +17,13 @@ This is a config file that allows for modularity. This file contains the name of
 In theory, different versions of trapsD## allows the user to pick different versions of Ecology data to use, should updates be released in the future. However, there is currently only one traps data version: **trapsD00**
 
 ---
+## climatology_all_source_types.sh
+
+This shellscript automates the climatology generation process.
+
+To use TRAPS, users need to generate climatology for three TRAPS types: point sources, tiny rivers, and pre-existing LO rivers. Running this script will automatically step through the make_climatology scripts for each of these sources types (so users do not need to independently run three different climatology scripts).
+
+---
 ## make_climatology scripts
 
 The climatology scripts condense the 1999-2017 Ecology timeseries data into yearly climatologies for each source. This section describes how these scripts work.


### PR DESCRIPTION
In this update, I made three major changes:

**1. Fixed object type error during forcing generation step**
The error that you sent me seemed to indicate that the river_direction object type was different for tiny rivers and pre-existing LO rivers. I was unable to reproduce the error on my machine, but I was able to confirm that the river_direction object type was indeed different for tiny rivers and pre-existing LO rivers. To fix this issue, I forced the river_direction object type to be an int for both classes of rivers. Since I was unable to reproduce the original issue, I am hoping that this update fixed the error.

**2. Created shellscript to automate climatology generation process**
You also recommended that I create a shellscript that will automatically run all three climatology generation scripts (for point sources, tiny rivers, and pre-existing LO rivers). I have added this shellscript and it now lives in LO/pre/trapsP00/climatology_all_source_types.sh. I also verified that this shellscript works on my machine.

**3. Updated READMEs for clarity and to reflect code changes**
Lastly, I updated the READMEs to instruct users to generate climatology on their remote machine (or whichever machine they wish to use to generate forcing). I also added new notes to reflect the addition of the climatology generation shellscript.