### PR TITLE
Add timezone-aware UTC handling to obs sources and new pcRaft mooring…

### DIFF
--- a/obs/README.md
+++ b/obs/README.md
@@ -115,19 +115,19 @@ Folders on apogee in `/dat1/parker/LO_output/obs` (I am maintaining these only o
   
 - **kc** King County monitoring data from modern stations. Station information was downloaded from: https://data.kingcounty.gov/Environment-Waste-Management/WLRD-Sites/wbhs-bbzf. Bottle data was downloaded from: https://data.kingcounty.gov/Environment-Waste-Management/Water-Quality/vwmt-pvjw. CTD data was received via email from Greg Ikeda, King County, to Dakota Mascarenas. Processed by Dakota Mascarenas. See the README in the associated folder for details. 
   - ctd 1998-2024
-  - bottle 1965-2023
+  - bottle 1965-2026 (NOTE: This inclues data duplicated in kc_whidbeyBasin, but is maintained here for consistency with King County's data management.)
 
 - **kc_his** King County monitoring data from historical stations. Received via email from Taylor Martin, King County, to Dakota Mascarenas. Processed by Dakota Mascarenas. See the README in the associated folder for details. Please note that temperature data for the full time range is included in both CTD and bottles, but comes from CTD cast. Salinity for the full time range is only in bottle data, but some CTD-measured salinity is included in ctd data at the end of the time range.
   - ctd 1965-2000
-  - bottle 1965-2000
+  - bottle 1965-2000 
   
 - **kc_pointJefferson** King County data collected near Point Jefferson. Received via email from Taylor Martin, King County, to Dakota Mascarenas. Station information was downloaded from: https://data.kingcounty.gov/Environment-Waste-Management/WLRD-Sites/wbhs-bbzf. Processed by Dakota Mascarenas. See the README in the associated folder for details.
   - ctd 1970-2023
   - bottle 1970-2023
   
-- **kc_whidbeyBasin** King County data collected in Whidbey Basin. CTD data downloaded from: https://data.kingcounty.gov/Environment-Waste-Management/Whidbey-Basin-CTD-Casts/uz4m-4d96. Processed by Dakota Mascarenas. See the README in the associated folder for details.
-  - ctd 2022-2024
-  - bottle None
+- **kc_whidbeyBasin** King County data collected in Whidbey Basin. Station information was downloaded from: https://data.kingcounty.gov/Environment-Waste-Management/WLRD-Sites/wbhs-bbzf. CTD data downloaded from: https://data.kingcounty.gov/Environment-Waste-Management/Whidbey-Basin-CTD-Casts/uz4m-4d96. Bottle data downloaded from: https://data.kingcounty.gov/Environment-Waste-Management/Whidbey-Bottle-Data/vuu8-t6kc. Processed by Dakota Mascarenas. See the README in the associated folder for details.
+  - ctd 2022-2026
+  - bottle 2022-2026 (NOTE: This is duplicated in kc, but is maintained here for consistency with King County's data management.)
 
 #### Notes on usage [2024.03.21 these notes need to be updated to reflect new additions to the collection: LineP, nceiPNW, NHL, and WOD]:
 - 2017 is a good year for validation, with bottle coverage from several sources.

--- a/obs/README.md
+++ b/obs/README.md
@@ -191,3 +191,7 @@ Attributes:
     - CE = Cape Elizabeth
   - **Naming convention:** The mooring depth is listed with its site id, e.g., CE042 is placed at ~42m; KL027 at ~27m; and CE015 is placed at ~15m.
 ![OCNMS Mooring Data](readme_plots/ocnms_2011_2023.png)
+
+- **pcRaft** Penn Cove mussel raft sonde data from the work conducted and discussed in, or adjacent to, Roberts & Carrington (2023): https://doi.org/10.1016/j.jembe.2023.151927. Data received from Emily Carrington. Processed by Dakota Mascarenas. See the README in the associated folder for details. Two stations are processed:
+  - `raft_main`: 2014-2019, hourly. Variables: CT, SA, DO (uM), PH, Chl (mg m-3).
+  - `raft_hiRes`: July-December 2017, hourly temperature profiles at 0.5-7 m depth (8 levels). Salinity is not directly measured (set to NaN); conservative temperature (CT) was computed using absolute salinity (SA) interpolated from `raft_main`.

--- a/obs/ecology_his/README.md
+++ b/obs/ecology_his/README.md
@@ -2,9 +2,7 @@
 
 Author: Dakota Mascarenas
 
-Finalized: 2025/09/03
-
-Last updated: 2025/11/25
+Last updated: 2026/04/13
 
 These files are WA Dept. of Ecology water column samples, both bottle and CTD. These were acquired via Public Records Request #P019860-042924 initiated 2024/04/29 by Dakota Mascarenas.
 
@@ -16,13 +14,15 @@ The list of files received is as follows:
 * Nov1989toDec1998CTDprofiles.xlsx
 * Nov1989toDec1998Discrete.xlsx
 
-NOTE: Despite the labeling on the Excel files received from WA Dept. of Ecology records request, we consider all data in  the file "Aug1973toOct1989CTDandDiscrete.xlsx" to be bottle (discrete) data. Email requests for information were sent on 2025/05/06 with follow up on 2025/09/03.
+NOTE: Despite the labeling on the Excel files received from WA Dept. of Ecology records request, we consider all data in the file "Aug1973toOct1989CTDandDiscrete.xlsx" to be bottle (discrete) data. Email requests for information were sent on 2025/05/06 with follow up on 2025/09/03.
 
 Metadata is found in these files. File data ranges are indicated in filenames.
 
 Also included in the associated LO_data folder is the file: "ParkerMacCreadyCoreStationInfoFeb2018.xlsx". This comes from apogee: dat1/parker/LO_data/ecology/ and gives station identifiers for modern and historical Ecology data.
 
 These datasets were initially primarily used for DO, temperature, and salinity. However, other variables are included (see Excel files).
+
+NOTE: Timestamps in "Aug1973toOct1989CTDandDiscrete.xlsx" and "Nov1989toDec1998Discrete.xlsx" are assumed to be in PST. Timestamps in "Nov1989toDec1998CTDprofiles.xlsx" are written in UTC. The processing scripts convert all timestamps to timezone-aware UTC for consistency with other LO observation sources.
 
 Bottle data availability:
 * DO: 1973-1983, 1988-1998

--- a/obs/ecology_his/process_bottle.py
+++ b/obs/ecology_his/process_bottle.py
@@ -7,9 +7,9 @@ Initial author date: 2024/07/10
 
 Finalized for group use: 2025/09/03
 
-Last updated: 2025/11/25 to correct conversion unit errors for N, P, and Si
-
 Written by: Dakota Mascarenas
+
+Most recent update: 2026/04/13
 
 NOTE: Despite the labeling on the Excel files received from WA Dept. of Ecology records request, we consider all data in this set bottle (discrete) data. Email requests for information were sent on 2025/05/06 with follow up on 2025/09/03.
 
@@ -65,6 +65,8 @@ big_df_raw1 = big_df_raw1.rename(columns = {'NO2+NO3':'NO2+NO3 (dissolved size f
 
 # Concatenate two datasets.
 big_df_raw = pd.concat([big_df_raw0, big_df_raw1])
+# Convert from PST (UTC-8, no daylight savings adjustment) to UTC.
+big_df_raw['Date'] = big_df_raw['Date'].dt.tz_localize('Etc/GMT+8').dt.tz_convert('UTC')
 
 # Merge station data.
 big_df = big_df_raw.merge(sta_df[['Station','lat', 'lon']], on = 'Station', how='left')
@@ -126,13 +128,13 @@ for year in year_list:
     if 'DO (mg -L)' in df.columns:
         df['DO (uM)'] = (1000/32) * df['DO (mg -L)']
     if 'NH4 (mg -L)' in df.columns:
-        df['NH4 (uM)'] = (1000/14) * df['NH4 (mg -L)']
+        df['NH4 (uM)'] = (1000/18) * df['NH4 (mg -L)']
     if 'NO3 (mg -L)' in df.columns:
-        df['NO3 (uM)'] = (1000/14) * df['NO3 (mg -L)']
+        df['NO3 (uM)'] = (1000/62) * df['NO3 (mg -L)']
     if 'SiO4 (mg -L)' in df.columns:
-        df['SiO4 (uM)'] = (1000/28.0855) * df['SiO4 (mg -L)']
+        df['SiO4 (uM)'] = (1000/92) * df['SiO4 (mg -L)']
     if 'PO4 (mg -L)' in df.columns:
-        df['PO4 (uM)'] = (1000/30.973762) * df['PO4 (mg -L)']
+        df['PO4 (uM)'] = (1000/95) * df['PO4 (mg -L)']        
     if 'Chl (ug -L)' in df.columns:
         df['Chl (mg m-3)'] = df['Chl (ug -L)']
     if 'NO2+NO3 (mg -L)' in df.columns:

--- a/obs/ecology_his/process_bottle.py
+++ b/obs/ecology_his/process_bottle.py
@@ -128,17 +128,17 @@ for year in year_list:
     if 'DO (mg -L)' in df.columns:
         df['DO (uM)'] = (1000/32) * df['DO (mg -L)']
     if 'NH4 (mg -L)' in df.columns:
-        df['NH4 (uM)'] = (1000/18) * df['NH4 (mg -L)']
+        df['NH4 (uM)'] = (1000/14) * df['NH4 (mg -L)']  # N atomic weight
     if 'NO3 (mg -L)' in df.columns:
-        df['NO3 (uM)'] = (1000/62) * df['NO3 (mg -L)']
+        df['NO3 (uM)'] = (1000/14) * df['NO3 (mg -L)']  # N atomic weight
     if 'SiO4 (mg -L)' in df.columns:
-        df['SiO4 (uM)'] = (1000/92) * df['SiO4 (mg -L)']
+        df['SiO4 (uM)'] = (1000/28.0855) * df['SiO4 (mg -L)']  # Si atomic weight
     if 'PO4 (mg -L)' in df.columns:
-        df['PO4 (uM)'] = (1000/95) * df['PO4 (mg -L)']        
+        df['PO4 (uM)'] = (1000/30.973762) * df['PO4 (mg -L)']  # P atomic weight        
     if 'Chl (ug -L)' in df.columns:
         df['Chl (mg m-3)'] = df['Chl (ug -L)']
     if 'NO2+NO3 (mg -L)' in df.columns:
-        df['NO3 (uM)'] = (1000/62) * (df['NO2+NO3 (mg -L)'] - df['NO2 (mg -L)'])
+        df['NO3 (uM)'] = (1000/14) * (df['NO2+NO3 (mg -L)'] - df['NO2 (mg -L)'])  # N atomic weight
     for vn in ['TA','DIC']:
         if (vn+' (umol -kg)') in df.columns:
             df[vn+' (uM)'] = (rho/1000) * df[vn+' (umol -kg)']

--- a/obs/ecology_his/process_ctd.py
+++ b/obs/ecology_his/process_ctd.py
@@ -107,13 +107,13 @@ for year in year_list:
     if 'DO (mg -L)' in df.columns:
         df['DO (uM)'] = (1000/32) * df['DO (mg -L)']
     if 'NH4 (mg -L)' in df.columns:
-        df['NH4 (uM)'] = (1000/18) * df['NH4 (mg -L)']
+        df['NH4 (uM)'] = (1000/14) * df['NH4 (mg -L)']  # N atomic weight
     if 'NO3 (mg -L)' in df.columns:
-        df['NO3 (uM)'] = (1000/62) * df['NO3 (mg -L)']
+        df['NO3 (uM)'] = (1000/14) * df['NO3 (mg -L)']  # N atomic weight
     if 'SiO4 (mg -L)' in df.columns:
-        df['SiO4 (uM)'] = (1000/92) * df['SiO4 (mg -L)']
+        df['SiO4 (uM)'] = (1000/28.0855) * df['SiO4 (mg -L)']  # Si atomic weight
     if 'PO4 (mg -L)' in df.columns:
-        df['PO4 (uM)'] = (1000/95) * df['PO4 (mg -L)']
+        df['PO4 (uM)'] = (1000/30.973762) * df['PO4 (mg -L)']  # P atomic weight
     if 'Chl (ug -L)' in df.columns:
         df['Chl (mg m-3)'] = df['Chl (ug -L)']
     for vn in ['TA','DIC']:

--- a/obs/ecology_his/process_ctd.py
+++ b/obs/ecology_his/process_ctd.py
@@ -7,9 +7,9 @@ Initial author date: 2024/07/10
 
 Finalized for group use: 2025/09/03
 
-Last updated: 2025/11/25 to correct conversion unit errors for N, P, and Si
-
 Written by: Dakota Mascarenas
+
+Most recent update: 2026/04/13
 
 NOTE: Despite the labeling on the Excel files received from WA Dept. of Ecology records request, we consider only data in this set to be CTD data. Email requests for information were sent on 2025/05/06 with follow up on 2025/09/03.
 
@@ -35,6 +35,8 @@ Lfun.make_dir(out_dir)
 
 # Load big data sets and stations.
 big_df_raw = pd.read_excel(in_dir0/ 'Nov1989toDec1998CTDprofiles.xlsx', parse_dates=['Date'])
+# Ensure times are timezone-aware UTC (raw data already in UTC).
+big_df_raw['Date'] = big_df_raw['Date'].dt.tz_localize('UTC')
 sta_df = pd.read_excel(in_dir0 / 'ParkerMacCreadyCoreStationInfoFeb2018.xlsx') #station list copied from apogee: dat1/parker/LO_data/ecology/
 
 # Parse station lat/lon.
@@ -105,13 +107,13 @@ for year in year_list:
     if 'DO (mg -L)' in df.columns:
         df['DO (uM)'] = (1000/32) * df['DO (mg -L)']
     if 'NH4 (mg -L)' in df.columns:
-        df['NH4 (uM)'] = (1000/14) * df['NH4 (mg -L)']
+        df['NH4 (uM)'] = (1000/18) * df['NH4 (mg -L)']
     if 'NO3 (mg -L)' in df.columns:
-        df['NO3 (uM)'] = (1000/14) * df['NO3 (mg -L)']
+        df['NO3 (uM)'] = (1000/62) * df['NO3 (mg -L)']
     if 'SiO4 (mg -L)' in df.columns:
-        df['SiO4 (uM)'] = (1000/28.0855) * df['SiO4 (mg -L)']
+        df['SiO4 (uM)'] = (1000/92) * df['SiO4 (mg -L)']
     if 'PO4 (mg -L)' in df.columns:
-        df['PO4 (uM)'] = (1000/30.973762) * df['PO4 (mg -L)']
+        df['PO4 (uM)'] = (1000/95) * df['PO4 (mg -L)']
     if 'Chl (ug -L)' in df.columns:
         df['Chl (mg m-3)'] = df['Chl (ug -L)']
     for vn in ['TA','DIC']:

--- a/obs/kc/README.md
+++ b/obs/kc/README.md
@@ -2,15 +2,15 @@
 
 Author: Dakota Mascarenas
 
-Last updated: 2026/04/13
+Last updated: 2026/04/21
 
 These files are from King County's marine offshore monitoring water column samples, both bottle and CTD.
 
-Bottle data is publically-accessible and was downloaded with data up to March 2024 by Dakota Mascarenas from https://data.kingcounty.gov/Environment-Waste-Management/Water-Quality/vwmt-pvjw.
+Bottle data is publically-accessible and was downloaded with data up to April 2026 by Dakota Mascarenas from https://data.kingcounty.gov/Environment-Waste-Management/Water-Quality/vwmt-pvjw.
 
 CTD data was received by Dakota Mascarenas from Greg Ikeda, King County, via file transfer on 2024/04/05.
 
-Station information downloaded in March 2024 by Dakota Mascarenas from: https://data.kingcounty.gov/Environment-Waste-Management/WLRD-Sites/wbhs-bbzf
+Station information downloaded in April 2026 by Dakota Mascarenas from: https://data.kingcounty.gov/Environment-Waste-Management/WLRD-Sites/wbhs-bbzf
 
 Sampling analysis plans and methods are included in the corresponding data folder.
 
@@ -19,6 +19,8 @@ Two email correspondences are attached for further metadata:
 * "his_methods_email - TM to DM 20250117.pdf" - explains sampling method change overtime especially for dissolved oxygen
 
 NOTE: Timestamps in the raw data are assumed to be in PST. The processing scripts convert these to timezone-aware UTC (+8 hours) for consistency with other LO observation sources.
+
+NOTE: This includes bottle data replicated in the folder kc_whidbeyBasin bottle data, but is included here since this is the format that King County maintains.
 
 NOTE: Light transmission is currently not considered in this data processing. However, for future use, reference https://green2.kingcounty.gov/marine/Monitoring/OffshoreCTD: "Light Transmission data prior to May 19, 2014 were referenced to air. After this date, all Light Transmission data are referenced to water. To convert the pre-May 19, 2014 data to ‘referenced to water’, multiply the values by 1.095."
 
@@ -30,13 +32,13 @@ CTD data availability:
 * SA: 1998-2024
 
 Bottle data availability
-* CT: 1965-1986, 1989, 1997-2023
-* Chl: 1997-2023
+* CT: 1965-2026
+* Chl: 1997-2026
 * DIC: 2015
-* DO: 1965-1973, 1997-2000
-* NH4: 1996-2023
-* NO3: 1997-2023
+* DO: 1965-2026
+* NH4: 1996-2026
+* NO3: 1997-2026
 * PO4: 1997-2010
-* SA: 1965-1986, 1989, 1997-2023
-* SiO4: 1997-2023
+* SA: 1965-2026
+* SiO4: 1997-2026
 * TA: 2015

--- a/obs/kc/README.md
+++ b/obs/kc/README.md
@@ -2,9 +2,7 @@
 
 Author: Dakota Mascarenas
 
-Finalized: 202/09/05
-
-Last updated: 2025/11/25
+Last updated: 2026/04/13
 
 These files are from King County's marine offshore monitoring water column samples, both bottle and CTD.
 
@@ -19,6 +17,8 @@ Sampling analysis plans and methods are included in the corresponding data folde
 Two email correspondences are attached for further metadata:
 * "metadata_questions_email - GI to DM 20230726.pdf" - answers to specific unit/processing questions
 * "his_methods_email - TM to DM 20250117.pdf" - explains sampling method change overtime especially for dissolved oxygen
+
+NOTE: Timestamps in the raw data are assumed to be in PST. The processing scripts convert these to timezone-aware UTC (+8 hours) for consistency with other LO observation sources.
 
 NOTE: Light transmission is currently not considered in this data processing. However, for future use, reference https://green2.kingcounty.gov/marine/Monitoring/OffshoreCTD: "Light Transmission data prior to May 19, 2014 were referenced to air. After this date, all Light Transmission data are referenced to water. To convert the pre-May 19, 2014 data to ‘referenced to water’, multiply the values by 1.095."
 

--- a/obs/kc/process_bottle.py
+++ b/obs/kc/process_bottle.py
@@ -9,9 +9,9 @@ Initial author date: 2024/07/13
 
 Finalized for group use: 2025/09/04
 
-Last updated: 2025/11/25 to correct conversion unit errors for N, P, and Si
-
 Written by: Dakota Mascarenas
+
+Most recent update: 2026/04/13
 
 """
 
@@ -33,7 +33,7 @@ out_dir = Ldir['LOo'] / 'obs' / source / otype
 Lfun.make_dir(out_dir)
 
 # Load big data set and stations.
-big_df_raw = pd.read_csv(in_dir0 / otype / 'Water_Quality_March2024.csv', low_memory=False)
+big_df_raw = pd.read_csv(in_dir0 / otype / 'Water_Quality_March2024.csv')
 sta_df = pd.read_csv(in_dir0 / 'WLRD_Sites_March2024.csv')
 
 # Merge station data.
@@ -72,6 +72,8 @@ big_df_use5 = big_df_use4.pivot_table(index = ['Profile ID', 'Collect DateTime',
                                       columns = 'Parameter', values = 'Value').reset_index()
 big_df_use6 = big_df_use5.copy()
 big_df_use6['time'] = pd.DatetimeIndex(big_df_use6['Collect DateTime'])
+# Convert from PST (UTC-8, no daylight savings adjustment) to UTC.
+big_df_use6['time'] = big_df_use6['time'].dt.tz_localize('Etc/GMT+8').dt.tz_convert('UTC')
 
 # Create unique cast IDs (cid).
 big_df_use6['cid'] = np.nan
@@ -126,13 +128,13 @@ for year in year_list:
     if 'DO (mg -L)' in df.columns:
         df['DO (uM)'] = (1000/32) * df['DO (mg -L)']
     if 'NH4 (mg -L)' in df.columns:
-        df['NH4 (uM)'] = (1000/14) * df['NH4 (mg -L)']
+        df['NH4 (uM)'] = (1000/18) * df['NH4 (mg -L)']
     if 'NO3 (mg -L)' in df.columns:
-        df['NO3 (uM)'] = (1000/14) * df['NO3 (mg -L)']
+        df['NO3 (uM)'] = (1000/62) * df['NO3 (mg -L)']
     if 'SiO4 (mg -L)' in df.columns:
-        df['SiO4 (uM)'] = (1000/28.0855) * df['SiO4 (mg -L)']
+        df['SiO4 (uM)'] = (1000/92) * df['SiO4 (mg -L)']
     if 'PO4 (mg -L)' in df.columns:
-        df['PO4 (uM)'] = (1000/30.973762) * df['PO4 (mg -L)']
+        df['PO4 (uM)'] = (1000/95) * df['PO4 (mg -L)']
     if 'Chl (ug -L)' in df.columns:
         df['Chl (mg m-3)'] = df['Chl (ug -L)']
     for vn in ['TA','DIC']:

--- a/obs/kc/process_bottle.py
+++ b/obs/kc/process_bottle.py
@@ -33,7 +33,7 @@ out_dir = Ldir['LOo'] / 'obs' / source / otype
 Lfun.make_dir(out_dir)
 
 # Load big data set and stations.
-big_df_raw = pd.read_csv(in_dir0 / otype / 'Water_Quality_20260421.csv') # updated 20260421
+big_df_raw = pd.read_csv(in_dir0 / otype / 'Water_Quality_20260421.csv', low_memory=False) # updated 20260421
 sta_df = pd.read_csv(in_dir0 / 'WLRD_Sites_20260421.csv')
 
 # Merge station data.

--- a/obs/kc/process_ctd.py
+++ b/obs/kc/process_ctd.py
@@ -9,9 +9,9 @@ Initial author date: 2023/07/13
 
 Finalized for public use: 2025/09/04
 
-Last updated: 2025/11/25 to correct conversion unit errors for N, P, and Si
-
 Written by: Dakota Mascarenas
+
+Most recent update: 2026/04/13
 
 """
 
@@ -41,7 +41,7 @@ fn = glob.glob(str(in_dir0) + '/' + otype + '/*.csv')
 # Initial clean.
 big_df_raw = pd.DataFrame()
 for f in fn:
-    raw = pd.read_csv(f, encoding='cp1252',low_memory=False)
+    raw = pd.read_csv(f, encoding='cp1252')
     if 'ï»¿Locator' in raw.columns:
         raw = raw.rename(columns={'ï»¿Locator':'Locator'})
     if big_df_raw.empty:
@@ -74,6 +74,8 @@ v_list = np.array(list(v_dict_use.keys()))
 # Clean column names.
 big_df_use6 = big_df_use0.copy()
 big_df_use6['time'] = pd.DatetimeIndex(big_df_use6['Sampledate'])
+# Convert from PST (UTC-8, no daylight savings adjustment) to UTC.
+big_df_use6['time'] = big_df_use6['time'].dt.tz_localize('Etc/GMT+8').dt.tz_convert('UTC')
 
 # Create unique cast IDs (cid).
 big_df_use6['cid'] = np.nan
@@ -129,13 +131,13 @@ for year in year_list:
     if 'DO (mg -L)' in df.columns:
         df['DO (uM)'] = (1000/32) * df['DO (mg -L)']
     if 'NH4 (mg -L)' in df.columns:
-        df['NH4 (uM)'] = (1000/14) * df['NH4 (mg -L)']
+        df['NH4 (uM)'] = (1000/18) * df['NH4 (mg -L)']
     if 'NO3 (mg -L)' in df.columns:
-        df['NO3 (uM)'] = (1000/14) * df['NO3 (mg -L)']
+        df['NO3 (uM)'] = (1000/62) * df['NO3 (mg -L)']
     if 'SiO4 (mg -L)' in df.columns:
-        df['SiO4 (uM)'] = (1000/28.0855) * df['SiO4 (mg -L)']
+        df['SiO4 (uM)'] = (1000/92) * df['SiO4 (mg -L)']
     if 'PO4 (mg -L)' in df.columns:
-        df['PO4 (uM)'] = (1000/30.973762) * df['PO4 (mg -L)']
+        df['PO4 (uM)'] = (1000/95) * df['PO4 (mg -L)']
     if 'Chl (ug -L)' in df.columns:
         df['Chl (mg m-3)'] = df['Chl (ug -L)']
     for vn in ['TA','DIC']:

--- a/obs/kc/process_ctd.py
+++ b/obs/kc/process_ctd.py
@@ -131,13 +131,13 @@ for year in year_list:
     if 'DO (mg -L)' in df.columns:
         df['DO (uM)'] = (1000/32) * df['DO (mg -L)']
     if 'NH4 (mg -L)' in df.columns:
-        df['NH4 (uM)'] = (1000/18) * df['NH4 (mg -L)']
+        df['NH4 (uM)'] = (1000/14) * df['NH4 (mg -L)']  # N atomic weight
     if 'NO3 (mg -L)' in df.columns:
-        df['NO3 (uM)'] = (1000/62) * df['NO3 (mg -L)']
+        df['NO3 (uM)'] = (1000/14) * df['NO3 (mg -L)']  # N atomic weight
     if 'SiO4 (mg -L)' in df.columns:
-        df['SiO4 (uM)'] = (1000/92) * df['SiO4 (mg -L)']
+        df['SiO4 (uM)'] = (1000/28.0855) * df['SiO4 (mg -L)']  # Si atomic weight
     if 'PO4 (mg -L)' in df.columns:
-        df['PO4 (uM)'] = (1000/95) * df['PO4 (mg -L)']
+        df['PO4 (uM)'] = (1000/30.973762) * df['PO4 (mg -L)']  # P atomic weight
     if 'Chl (ug -L)' in df.columns:
         df['Chl (mg m-3)'] = df['Chl (ug -L)']
     for vn in ['TA','DIC']:

--- a/obs/kc/process_ctd.py
+++ b/obs/kc/process_ctd.py
@@ -41,7 +41,7 @@ fn = glob.glob(str(in_dir0) + '/' + otype + '/*.csv')
 # Initial clean.
 big_df_raw = pd.DataFrame()
 for f in fn:
-    raw = pd.read_csv(f, encoding='cp1252')
+    raw = pd.read_csv(f, encoding='cp1252', low_memory=False)
     if 'ï»¿Locator' in raw.columns:
         raw = raw.rename(columns={'ï»¿Locator':'Locator'})
     if big_df_raw.empty:

--- a/obs/kc_his/README.md
+++ b/obs/kc_his/README.md
@@ -2,9 +2,7 @@
 
 Author: Dakota Mascarenas
 
-Finalized: 2025/09/05
-
-Last updated: 2025/12/01
+Last updated: 2026/04/13
 
 These files are from King County's monitoring of the water column near Point Jefferson, both bottle samples at now-defunct historical stations.
 
@@ -13,6 +11,8 @@ Data was received via email from Taylor Martin, King County, to Dakota Mascarena
 Email correspondences is included in the corresponding data folder for methods information: "his_methods_email - TM to DM 20250117.pdf"
 
 NOTE: "field" data and temperature are from CTD and others are from bottle. I use temperature from CTD for bottles for ease of use in observation/model comparison.This is all included in "bottle_DO_data_for_Dakota.csv" despite the name.
+
+NOTE: Timestamps in the raw data are mostly date-only (midnight), assumed to be in PST. The processing scripts convert these to timezone-aware UTC (+8 hours) for consistency with other LO observation sources.
 
 CTD data availability:
 * Chl: 1998-2000

--- a/obs/kc_his/process_bottle.py
+++ b/obs/kc_his/process_bottle.py
@@ -35,7 +35,7 @@ out_dir = Ldir['LOo'] / 'obs' / source / otype
 Lfun.make_dir(out_dir)
 
 # Load big data set and stations.
-big_df_raw = pd.read_csv(in_dir0/ 'old_do_data.csv') # converted from original .xlsx format
+big_df_raw = pd.read_csv(in_dir0/ 'old_do_data.csv', low_memory=False) # converted from original .xlsx format
 sta_df = pd.read_csv(in_dir0 / 'old_do_stations.csv')
 
 # Merge station data.

--- a/obs/kc_his/process_bottle.py
+++ b/obs/kc_his/process_bottle.py
@@ -127,13 +127,13 @@ for year in year_list:
     if 'DO (mg -L)' in df.columns:
         df['DO (uM)'] = (1000/32) * df['DO (mg -L)']
     if 'NH4 (mg -L)' in df.columns:
-        df['NH4 (uM)'] = (1000/18) * df['NH4 (mg -L)']
+        df['NH4 (uM)'] = (1000/14) * df['NH4 (mg -L)']  # N atomic weight
     if 'NO3 (mg -L)' in df.columns:
-        df['NO3 (uM)'] = (1000/62) * df['NO3 (mg -L)']
+        df['NO3 (uM)'] = (1000/14) * df['NO3 (mg -L)']  # N atomic weight
     if 'SiO4 (mg -L)' in df.columns:
-        df['SiO4 (uM)'] = (1000/92) * df['SiO4 (mg -L)']
+        df['SiO4 (uM)'] = (1000/28.0855) * df['SiO4 (mg -L)']  # Si atomic weight
     if 'PO4 (mg -L)' in df.columns:
-        df['PO4 (uM)'] = (1000/95) * df['PO4 (mg -L)']
+        df['PO4 (uM)'] = (1000/30.973762) * df['PO4 (mg -L)']  # P atomic weight
     if 'Chl (ug -L)' in df.columns:
         df['Chl (mg m-3)'] = df['Chl (ug -L)']
     for vn in ['TA','DIC']:

--- a/obs/kc_his/process_bottle.py
+++ b/obs/kc_his/process_bottle.py
@@ -7,9 +7,9 @@ Initial author date: 2024/03/29
 
 Finalized for group use: 2025/09/05
 
-Last updated: 2025/12/01 to correct conversion unit errors for N, P, and Si
-
 Written by: Dakota Mascarenas
+
+Most recent update: 2026/04/13
 
 NOTE: "field" data and temperature are from CTD. Here we consider just bottle data (and CTD temperature concurrently).
 
@@ -35,7 +35,7 @@ out_dir = Ldir['LOo'] / 'obs' / source / otype
 Lfun.make_dir(out_dir)
 
 # Load big data set and stations.
-big_df_raw = pd.read_csv(in_dir0/ 'old_do_data.csv', low_memory=False) # converted from original .xlsx format
+big_df_raw = pd.read_csv(in_dir0/ 'old_do_data.csv') # converted from original .xlsx format
 sta_df = pd.read_csv(in_dir0 / 'old_do_stations.csv')
 
 # Merge station data.
@@ -70,6 +70,8 @@ big_df_use6['time'] = pd.DatetimeIndex(big_df_use6['COLLECTDATE'])
 start_date = pd.Timestamp('2025-01-01')
 mask = (big_df_use6['time'] >= start_date)
 big_df_use6.loc[mask, 'time'] -= pd.DateOffset(years=100)
+# Convert from PST (UTC-8, no daylight savings adjustment) to UTC.
+big_df_use6['time'] = big_df_use6['time'].dt.tz_localize('Etc/GMT+8').dt.tz_convert('UTC')
 
 # Create unique cast IDs (cid).
 big_df_use6['cid'] = np.nan
@@ -125,13 +127,13 @@ for year in year_list:
     if 'DO (mg -L)' in df.columns:
         df['DO (uM)'] = (1000/32) * df['DO (mg -L)']
     if 'NH4 (mg -L)' in df.columns:
-        df['NH4 (uM)'] = (1000/14) * df['NH4 (mg -L)']
+        df['NH4 (uM)'] = (1000/18) * df['NH4 (mg -L)']
     if 'NO3 (mg -L)' in df.columns:
-        df['NO3 (uM)'] = (1000/14) * df['NO3 (mg -L)']
+        df['NO3 (uM)'] = (1000/62) * df['NO3 (mg -L)']
     if 'SiO4 (mg -L)' in df.columns:
-        df['SiO4 (uM)'] = (1000/28.0855) * df['SiO4 (mg -L)']
+        df['SiO4 (uM)'] = (1000/92) * df['SiO4 (mg -L)']
     if 'PO4 (mg -L)' in df.columns:
-        df['PO4 (uM)'] = (1000/30.973762) * df['PO4 (mg -L)']
+        df['PO4 (uM)'] = (1000/95) * df['PO4 (mg -L)']
     if 'Chl (ug -L)' in df.columns:
         df['Chl (mg m-3)'] = df['Chl (ug -L)']
     for vn in ['TA','DIC']:

--- a/obs/kc_his/process_ctd.py
+++ b/obs/kc_his/process_ctd.py
@@ -36,7 +36,7 @@ out_dir = Ldir['LOo'] / 'obs' / source / otype
 Lfun.make_dir(out_dir)
 
 # Load big data set and stations.
-big_df_raw = pd.read_csv(in_dir0/ 'old_do_data.csv') # converted from original .xlsx format
+big_df_raw = pd.read_csv(in_dir0/ 'old_do_data.csv', low_memory=False) # converted from original .xlsx format
 sta_df = pd.read_csv(in_dir0 / 'old_do_stations.csv')
 
 # Merge station data.

--- a/obs/kc_his/process_ctd.py
+++ b/obs/kc_his/process_ctd.py
@@ -7,9 +7,9 @@ Initial author date: 2025/09/05
 
 Finalized for group use: 2025/09/05
 
-Last updated: 2025/12/01 to correct conversion unit errors for N, P, and Si
-
 Written by: Dakota Mascarenas
+
+Most recent update: 2026/04/13
 
 NOTE: "field" data and temperature are from CTD and others are from bottle. Here, considering just CTD.
 
@@ -36,7 +36,7 @@ out_dir = Ldir['LOo'] / 'obs' / source / otype
 Lfun.make_dir(out_dir)
 
 # Load big data set and stations.
-big_df_raw = pd.read_csv(in_dir0/ 'old_do_data.csv', low_memory=False) # converted from original .xlsx format
+big_df_raw = pd.read_csv(in_dir0/ 'old_do_data.csv') # converted from original .xlsx format
 sta_df = pd.read_csv(in_dir0 / 'old_do_stations.csv')
 
 # Merge station data.
@@ -67,6 +67,8 @@ big_df_use6['time'] = pd.DatetimeIndex(big_df_use6['COLLECTDATE'])
 start_date = pd.Timestamp('2025-01-01')
 mask = (big_df_use6['time'] >= start_date)
 big_df_use6.loc[mask, 'time'] -= pd.DateOffset(years=100)
+# Convert from PST (UTC-8, no daylight savings adjustment) to UTC.
+big_df_use6['time'] = big_df_use6['time'].dt.tz_localize('Etc/GMT+8').dt.tz_convert('UTC')
 
 # Create unique cast IDs (cid).
 big_df_use6['cid'] = np.nan
@@ -122,13 +124,13 @@ for year in year_list:
     if 'DO (mg -L)' in df.columns:
         df['DO (uM)'] = (1000/32) * df['DO (mg -L)']
     if 'NH4 (mg -L)' in df.columns:
-        df['NH4 (uM)'] = (1000/14) * df['NH4 (mg -L)']
+        df['NH4 (uM)'] = (1000/18) * df['NH4 (mg -L)']
     if 'NO3 (mg -L)' in df.columns:
-        df['NO3 (uM)'] = (1000/14) * df['NO3 (mg -L)']
+        df['NO3 (uM)'] = (1000/62) * df['NO3 (mg -L)']
     if 'SiO4 (mg -L)' in df.columns:
-        df['SiO4 (uM)'] = (1000/28.0855) * df['SiO4 (mg -L)']
+        df['SiO4 (uM)'] = (1000/92) * df['SiO4 (mg -L)']
     if 'PO4 (mg -L)' in df.columns:
-        df['PO4 (uM)'] = (1000/30.973762) * df['PO4 (mg -L)']
+        df['PO4 (uM)'] = (1000/95) * df['PO4 (mg -L)']
     if 'Chl (ug -L)' in df.columns:
         df['Chl (mg m-3)'] = df['Chl (ug -L)']
     for vn in ['TA','DIC']:

--- a/obs/kc_his/process_ctd.py
+++ b/obs/kc_his/process_ctd.py
@@ -124,13 +124,13 @@ for year in year_list:
     if 'DO (mg -L)' in df.columns:
         df['DO (uM)'] = (1000/32) * df['DO (mg -L)']
     if 'NH4 (mg -L)' in df.columns:
-        df['NH4 (uM)'] = (1000/18) * df['NH4 (mg -L)']
+        df['NH4 (uM)'] = (1000/14) * df['NH4 (mg -L)']  # N atomic weight
     if 'NO3 (mg -L)' in df.columns:
-        df['NO3 (uM)'] = (1000/62) * df['NO3 (mg -L)']
+        df['NO3 (uM)'] = (1000/14) * df['NO3 (mg -L)']  # N atomic weight
     if 'SiO4 (mg -L)' in df.columns:
-        df['SiO4 (uM)'] = (1000/92) * df['SiO4 (mg -L)']
+        df['SiO4 (uM)'] = (1000/28.0855) * df['SiO4 (mg -L)']  # Si atomic weight
     if 'PO4 (mg -L)' in df.columns:
-        df['PO4 (uM)'] = (1000/95) * df['PO4 (mg -L)']
+        df['PO4 (uM)'] = (1000/30.973762) * df['PO4 (mg -L)']  # P atomic weight
     if 'Chl (ug -L)' in df.columns:
         df['Chl (mg m-3)'] = df['Chl (ug -L)']
     for vn in ['TA','DIC']:

--- a/obs/kc_pointJefferson/README.md
+++ b/obs/kc_pointJefferson/README.md
@@ -2,9 +2,7 @@
 
 Author: Dakota Mascarenas
 
-Finalized: 2025/09/05
-
-Last updated: 2025/11/25
+Last updated: 2026/04/13
 
 These files are from King County's monitoring of the water column near Point Jefferson, both bottle and CTD samples.
 

--- a/obs/kc_pointJefferson/process_bottle.py
+++ b/obs/kc_pointJefferson/process_bottle.py
@@ -39,7 +39,7 @@ out_dir = Ldir['LOo'] / 'obs' / source / otype
 Lfun.make_dir(out_dir)
 
 # Load big data set and stations.
-big_df_raw = pd.read_csv(in_dir0/ 'bottle_DO_data_for_Dakota.csv')
+big_df_raw = pd.read_csv(in_dir0/ 'bottle_DO_data_for_Dakota.csv', low_memory=False)
 sta_df = pd.read_csv(in_dir0 / 'WLRD_Sites_March2024.csv')
 
 # Merge station data.

--- a/obs/kc_pointJefferson/process_bottle.py
+++ b/obs/kc_pointJefferson/process_bottle.py
@@ -9,9 +9,9 @@ Initial author date: 2024/05/09
 
 Finalized for group use: 2025/09/05
 
-Last updated: 2025/11/25 to correct conversion unit errors for N, P, and Si
-
 Written by: Dakota Mascarenas
+
+Most recent update: 2026/04/13
 
 NOTE: TaylorQuality and TaylorNote columns are considered insofar as to filter to only TaylorQuality = 'ok'.
 
@@ -39,7 +39,7 @@ out_dir = Ldir['LOo'] / 'obs' / source / otype
 Lfun.make_dir(out_dir)
 
 # Load big data set and stations.
-big_df_raw = pd.read_csv(in_dir0/ 'bottle_DO_data_for_Dakota.csv', low_memory=False)
+big_df_raw = pd.read_csv(in_dir0/ 'bottle_DO_data_for_Dakota.csv')
 sta_df = pd.read_csv(in_dir0 / 'WLRD_Sites_March2024.csv')
 
 # Merge station data.
@@ -69,6 +69,8 @@ big_df_use5 = big_df_use2.pivot_table(index = ['CollectDateTime', 'Depth','Latit
                                       columns = 'ParmDisplayName', values = 'Value').reset_index()
 big_df_use6 = big_df_use5.copy()
 big_df_use6['time'] = pd.DatetimeIndex(big_df_use6['CollectDateTime'])
+# Ensure times are timezone-aware UTC (raw data already in UTC).
+big_df_use6['time'] = big_df_use6['time'].dt.tz_localize('UTC')
 
 # Create unique cast IDs (cid).
 big_df_use7 = big_df_use6.copy()
@@ -123,13 +125,13 @@ for year in year_list:
     if 'DO (mg -L)' in df.columns:
         df['DO (uM)'] = (1000/32) * df['DO (mg -L)']
     if 'NH4 (mg -L)' in df.columns:
-        df['NH4 (uM)'] = (1000/14) * df['NH4 (mg -L)']
+        df['NH4 (uM)'] = (1000/14) * df['NH4 (mg -L)']  # N atomic weight
     if 'NO3 (mg -L)' in df.columns:
-        df['NO3 (uM)'] = (1000/14) * df['NO3 (mg -L)']
+        df['NO3 (uM)'] = (1000/14) * df['NO3 (mg -L)']  # N atomic weight
     if 'SiO4 (mg -L)' in df.columns:
-        df['SiO4 (uM)'] = (1000/28.0855) * df['SiO4 (mg -L)']
+        df['SiO4 (uM)'] = (1000/28.0855) * df['SiO4 (mg -L)']  # Si atomic weight
     if 'PO4 (mg -L)' in df.columns:
-        df['PO4 (uM)'] = (1000/30.973762) * df['PO4 (mg -L)']
+        df['PO4 (uM)'] = (1000/30.973762) * df['PO4 (mg -L)']  # P atomic weight
     if 'Chl (ug -L)' in df.columns:
         df['Chl (mg m-3)'] = df['Chl (ug -L)']
     for vn in ['TA','DIC']:

--- a/obs/kc_pointJefferson/process_ctd.py
+++ b/obs/kc_pointJefferson/process_ctd.py
@@ -40,7 +40,7 @@ out_dir = Ldir['LOo'] / 'obs' / source / otype
 Lfun.make_dir(out_dir)
 
 # Load big data set and stations.
-big_df_raw = pd.read_csv(in_dir0/ 'bottle_DO_data_for_Dakota.csv') #confusingly named but fine
+big_df_raw = pd.read_csv(in_dir0/ 'bottle_DO_data_for_Dakota.csv', low_memory=False) #confusingly named but fine
 sta_df = pd.read_csv(in_dir0 / 'WLRD_Sites_March2024.csv')
 
 # Merge station data.

--- a/obs/kc_pointJefferson/process_ctd.py
+++ b/obs/kc_pointJefferson/process_ctd.py
@@ -125,13 +125,13 @@ for year in year_list:
     if 'DO (mg -L)' in df.columns:
         df['DO (uM)'] = (1000/32) * df['DO (mg -L)']
     if 'NH4 (mg -L)' in df.columns:
-        df['NH4 (uM)'] = (1000/18) * df['NH4 (mg -L)']
+        df['NH4 (uM)'] = (1000/14) * df['NH4 (mg -L)']  # N atomic weight
     if 'NO3 (mg -L)' in df.columns:
-        df['NO3 (uM)'] = (1000/62) * df['NO3 (mg -L)']
+        df['NO3 (uM)'] = (1000/14) * df['NO3 (mg -L)']  # N atomic weight
     if 'SiO4 (mg -L)' in df.columns:
-        df['SiO4 (uM)'] = (1000/92) * df['SiO4 (mg -L)']
+        df['SiO4 (uM)'] = (1000/28.0855) * df['SiO4 (mg -L)']  # Si atomic weight
     if 'PO4 (mg -L)' in df.columns:
-        df['PO4 (uM)'] = (1000/95) * df['PO4 (mg -L)']
+        df['PO4 (uM)'] = (1000/30.973762) * df['PO4 (mg -L)']  # P atomic weight
     if 'Chl (ug -L)' in df.columns:
         df['Chl (mg m-3)'] = df['Chl (ug -L)']
     for vn in ['TA','DIC']:

--- a/obs/kc_pointJefferson/process_ctd.py
+++ b/obs/kc_pointJefferson/process_ctd.py
@@ -9,9 +9,9 @@ Initial author date: 2024/05/09
 
 Finalized for group use: 2025/09/05
 
-Last updated: 2025/11/25 to correct conversion unit errors for N, P, and Si
-
 Written by: Dakota Mascarenas
+
+Most recent update: 2026/04/13
 
 NOTE: TaylorQuality and TaylorNote columns are considered insofar as to filter to only TaylorQuality = 'ok'.
 
@@ -40,7 +40,7 @@ out_dir = Ldir['LOo'] / 'obs' / source / otype
 Lfun.make_dir(out_dir)
 
 # Load big data set and stations.
-big_df_raw = pd.read_csv(in_dir0/ 'bottle_DO_data_for_Dakota.csv', low_memory=False) #confusingly named but fine
+big_df_raw = pd.read_csv(in_dir0/ 'bottle_DO_data_for_Dakota.csv') #confusingly named but fine
 sta_df = pd.read_csv(in_dir0 / 'WLRD_Sites_March2024.csv')
 
 # Merge station data.
@@ -69,6 +69,8 @@ big_df_use5 = big_df_use2.pivot_table(index = ['CollectDateTime', 'Depth','Latit
                                       columns = 'ParmDisplayName', values = 'Value').reset_index()
 big_df_use6 = big_df_use5.copy()
 big_df_use6['time'] = pd.DatetimeIndex(big_df_use6['CollectDateTime'])
+# Ensure times are timezone-aware UTC (raw data already in UTC).
+big_df_use6['time'] = big_df_use6['time'].dt.tz_localize('UTC')
 
 # Create unique cast IDs (cid).
 big_df_use7 = big_df_use6.copy()
@@ -123,13 +125,13 @@ for year in year_list:
     if 'DO (mg -L)' in df.columns:
         df['DO (uM)'] = (1000/32) * df['DO (mg -L)']
     if 'NH4 (mg -L)' in df.columns:
-        df['NH4 (uM)'] = (1000/14) * df['NH4 (mg -L)']
+        df['NH4 (uM)'] = (1000/18) * df['NH4 (mg -L)']
     if 'NO3 (mg -L)' in df.columns:
-        df['NO3 (uM)'] = (1000/14) * df['NO3 (mg -L)']
+        df['NO3 (uM)'] = (1000/62) * df['NO3 (mg -L)']
     if 'SiO4 (mg -L)' in df.columns:
-        df['SiO4 (uM)'] = (1000/28.0855) * df['SiO4 (mg -L)']
+        df['SiO4 (uM)'] = (1000/92) * df['SiO4 (mg -L)']
     if 'PO4 (mg -L)' in df.columns:
-        df['PO4 (uM)'] = (1000/30.973762) * df['PO4 (mg -L)']
+        df['PO4 (uM)'] = (1000/95) * df['PO4 (mg -L)']
     if 'Chl (ug -L)' in df.columns:
         df['Chl (mg m-3)'] = df['Chl (ug -L)']
     for vn in ['TA','DIC']:

--- a/obs/kc_whidbeyBasin/README.md
+++ b/obs/kc_whidbeyBasin/README.md
@@ -2,9 +2,7 @@
 
 Author: Dakota Mascarenas
 
-Finalized: 2025/09/05
-
-Last updated: 2025/11/24
+Last updated: 2025/09/05
 
 These files are from King County's marine offshore monitoring water column CTD samples in Whidbey Basin.
 
@@ -21,6 +19,8 @@ Two email correspondences are attached for further metadata:
 NOTE: Light transmission is currently not considered in this data processing.
 
 NOTE: Whidbey Basin bottle samples from this time period are included in the kc bottle data.
+
+NOTE: Timestamps in the raw data are assumed to be in PST. The processing script converts these to timezone-aware UTC (+8 hours) for consistency with other LO observation sources.
 
 CTD data availability:
 * CT: 2022-2024

--- a/obs/kc_whidbeyBasin/README.md
+++ b/obs/kc_whidbeyBasin/README.md
@@ -2,13 +2,15 @@
 
 Author: Dakota Mascarenas
 
-Last updated: 2025/09/05
+Last updated: 2026/04/21
 
 These files are from King County's marine offshore monitoring water column CTD samples in Whidbey Basin.
 
-CTD data is publically-accessible and was downloaded with data up to April 2024 by Dakota Mascarenas from  https://data.kingcounty.gov/Environment-Waste-Management/Whidbey-Basin-CTD-Casts/uz4m-4d96
+CTD data is publically-accessible and was downloaded with data up to April 2026 by Dakota Mascarenas from  https://data.kingcounty.gov/Environment-Waste-Management/Whidbey-Basin-CTD-Casts/uz4m-4d96
 
-Station information downloaded in March 2024 by Dakota Mascarenas from: https://data.kingcounty.gov/Environment-Waste-Management/WLRD-Sites/wbhs-bbzf
+Bottle data is publically-accessible and was downloaded with data up to April 2026 by Dakota Mascarenas from  https://data.kingcounty.gov/Environment-Waste-Management/Whidbey-Bottle-Data/vuu8-t6kc/data_preview
+
+Station information downloaded in April 2026 by Dakota Mascarenas from: https://data.kingcounty.gov/Environment-Waste-Management/WLRD-Sites/wbhs-bbzf/
 
 Sampling analysis plans and methods are included in the corresponding data folder.
 
@@ -18,13 +20,23 @@ Two email correspondences are attached for further metadata:
 
 NOTE: Light transmission is currently not considered in this data processing.
 
-NOTE: Whidbey Basin bottle samples from this time period are included in the kc bottle data.
+NOTE: Bottle data is replicated in the folder kc bottle data, but is included here since this is the format that King County maintains.
 
 NOTE: Timestamps in the raw data are assumed to be in PST. The processing script converts these to timezone-aware UTC (+8 hours) for consistency with other LO observation sources.
 
 CTD data availability:
-* CT: 2022-2024
-* Chl: 2022-2024
-* DO: 2022-2024
-* NO3: 2022-2024
-* SA: 2022-2024
+* CT: 2022-2026
+* Chl: 2022-2026
+* DO: 2022-2026
+* NO3: 2022-2026
+* SA: 2022-2026
+
+Bottle data availability:
+* CT: 2022-2026
+* Chl: 2022-2026
+* DO: 2022-2026
+* NO3: 2022-2026
+* NH4: 2022-2026
+* PO4: 2022-2026
+* SA: 2022-2026
+* SiO4: 2022-2026

--- a/obs/kc_whidbeyBasin/process_bottle.py
+++ b/obs/kc_whidbeyBasin/process_bottle.py
@@ -1,15 +1,15 @@
 """
-Code to process the King County Water Quality BOTTLE data for Puget Sound.
+Code to process the King County Water Quality BOTTLE data for Whidbey Basin in Puget Sound.
 
-To process publically-accessible data downloaded by Dakota Mascarenas from https://data.kingcounty.gov/Environment-Waste-Management/Water-Quality/vwmt-pvjw.
+To process publically-accessible data downloaded by Dakota Mascarenas from: https://data.kingcounty.gov/Environment-Waste-Management/Whidbey-Bottle-Data/vuu8-t6kc
 
 Station information downloaded by Dakota Mascarenas from: https://data.kingcounty.gov/Environment-Waste-Management/WLRD-Sites/wbhs-bbzf
 
-NOTE: This includes data replicated in the folder kc_whidbeyBasin bottle data, but is included here since this is the format that King County maintains.
+NOTE: This data is replicated in the folder kc bottle data, but is included here since this is the format that King County maintains.
 
-Initial author date: 2024/07/13
+Initial author date: 2026/04/21
 
-Finalized for group use: 2025/09/04
+Finalized for public use: 2026/04/21
 
 Written by: Dakota Mascarenas
 
@@ -23,55 +23,60 @@ from lo_tools import Lfun, obs_functions
 Ldir = Lfun.Lstart()
 
 # source location
-source = 'kc'
+source = 'kc_whidbeyBasin'
 otype = 'bottle'
-in_dir0 = Ldir['data'] / 'obs' / source
-year_list = range(1963,2027)
+in_dir0 = Ldir['data'] / 'obs' / source / otype
+year_list = range(2022,2027)
 
 # output location
 out_dir = Ldir['LOo'] / 'obs' / source / otype
 Lfun.make_dir(out_dir)
 
 # Load big data set and stations.
-big_df_raw = pd.read_csv(in_dir0 / otype / 'Water_Quality_20260421.csv') # updated 20260421
-sta_df = pd.read_csv(in_dir0 / 'WLRD_Sites_20260421.csv')
+big_df_raw = pd.read_csv(in_dir0 / 'Whidbey_Bottle_Data_20260421.csv')
+sta_df = pd.read_csv(Ldir['data'] / 'obs' / source / 'WLRD_Sites_20260421.csv')
 
 # Merge station data.
-big_df = big_df_raw.merge(sta_df[['Locator','Latitude', 'Longitude']], on = 'Locator', how='left')
+big_df = big_df_raw.merge(sta_df[['Locator','Latitude', 'Longitude']], on='Locator', how='left')
 
-# Select for marine offshore monitoring stations.
+# Select only marine offshore stations.
 big_df_use0 = big_df[big_df['Site Type'] == 'Marine Offshore']
 
-# Create dictionary and filter for important variable and column names.
+# Create dictionary for important variable and parameter names.
 cols_all = big_df_use0['Parameter'].unique()
-v_dict = {}
 v_dict = {col:'' for col in cols_all}
 v_dict['Temperature'] = 'IT'
 v_dict['Salinity'] = 'SP'
 v_dict['Dissolved Oxygen'] = 'DO (mg -L)'
-v_dict['Nitrite + Nitrate Nitrogen'] = 'NO3 (mg -L)' # measured together assuming 0 NO2
+v_dict['Nitrite + Nitrate Nitrogen'] = 'NO3 (mg -L)' # measured together assuming a 0 NO2
 v_dict['Ammonia Nitrogen'] = 'NH4 (mg -L)'
-v_dict['Total Phosphorus'] = 'PO4 (mg -L)'
-v_dict['Silica'] = 'SiO4 (mg -L)' 
-v_dict['Total Alkalinity'] = 'TA (umol -kg)'
-v_dict['Dissolved Inorganic Carbon'] = 'DIC (umol -kg)'
+v_dict['Orthophosphate Phosphorus'] = 'PO4 (mg -L)'
+v_dict['Silica'] = 'SiO4 (mg -L)'
 v_dict['Chlorophyll a'] = 'Chl (ug -L)'
 v_dict_use = {}
 for v in v_dict.keys():
     if len(v_dict[v]) > 0:
         v_dict_use[v] = v_dict[v]
-v_list = np.array(list(v_dict_use.keys()))
-big_df_use1 = big_df_use0[big_df_use0['Parameter'].isin(v_list)]
+v_list = np.array(list(v_dict_use.keys())) #redundant but fine
 
-# Clean out repeated data and clean dataframe.
-big_df_use2 = big_df_use1[['Sample ID','Profile ID', 'Collect DateTime', 'Depth (m)', 'Parameter', 'Value', 'Replicates', 'Replicate Of', 'Latitude', 'Longitude', 'Locator']]
-replicates = big_df_use2['Replicates'].dropna().unique()
-big_df_use3 = big_df_use2[~big_df_use2['Sample ID'].isin(replicates)]
-big_df_use4 = big_df_use3[['Profile ID', 'Collect DateTime', 'Depth (m)', 'Parameter', 'Value', 'Latitude', 'Longitude', 'Locator']]
-big_df_use5 = big_df_use4.pivot_table(index = ['Profile ID', 'Collect DateTime', 'Depth (m)', 'Latitude', 'Longitude', 'Locator'],
-                                      columns = 'Parameter', values = 'Value').reset_index()
+# Keep only selected parameters and clean repeated records.
+big_df_use1 = big_df_use0[big_df_use0['Parameter'].isin(v_list)].copy()
+big_df_use1['Value'] = pd.to_numeric(big_df_use1['Value'], errors='coerce')
+big_df_use2 = big_df_use1[['Sample ID', 'Profile ID', 'Collect DateTime', 'Depth (m)', 'Parameter',
+                           'Value', 'Replicates', 'Latitude', 'Longitude', 'Locator']].copy()
+replicates = big_df_use2['Replicates'].dropna().astype(str).unique()
+big_df_use3 = big_df_use2[~big_df_use2['Sample ID'].astype(str).isin(replicates)]
+big_df_use4 = big_df_use3[['Profile ID', 'Collect DateTime', 'Depth (m)', 'Parameter',
+                           'Value', 'Latitude', 'Longitude', 'Locator']].copy()
+
+# Pivot from long to wide format.
+big_df_use5 = big_df_use4.pivot_table(index=['Profile ID', 'Collect DateTime', 'Depth (m)',
+                                             'Latitude', 'Longitude', 'Locator'],
+                                      columns='Parameter', values='Value').reset_index()
+
+# Clean column names.
 big_df_use6 = big_df_use5.copy()
-big_df_use6['time'] = pd.DatetimeIndex(big_df_use6['Collect DateTime'])
+big_df_use6['time'] = pd.to_datetime(big_df_use6['Collect DateTime'])
 # Convert from PST (UTC-8, no daylight savings adjustment) to UTC.
 big_df_use6['time'] = big_df_use6['time'].dt.tz_localize('Etc/GMT+8').dt.tz_convert('UTC')
 
@@ -79,10 +84,10 @@ big_df_use6['time'] = big_df_use6['time'].dt.tz_localize('Etc/GMT+8').dt.tz_conv
 big_df_use6['cid'] = np.nan
 big_df_use7 = big_df_use6.copy()
 c = 0
-for pid in big_df_use6['Profile ID'].unique(): # profile ID is unique identifier
-    big_df_use7.loc[big_df_use6['Profile ID'] == pid, 'cid'] = c
-    c+=1
-    
+for pid in big_df_use7['Profile ID'].unique(): # profile ID is unique identifier
+    big_df_use7.loc[big_df_use7['Profile ID'] == pid, 'cid'] = c
+    c += 1
+
 # Rename some columns in variable dictionary.
 v_dict['cid'] = 'cid'
 v_dict['time'] = 'time'
@@ -99,7 +104,7 @@ for year in year_list:
     out_fn = out_dir / (ys + '.p')
     info_out_fn = out_dir / ('info_' + ys + '.p')
     t = pd.DatetimeIndex(df0.time)
-    df1 = df0.loc[t.year==year,:].copy()   
+    df1 = df0.loc[t.year==year,:].copy()
     # select and rename variables
     df = pd.DataFrame()
     for v in df1.columns:
@@ -109,21 +114,32 @@ for year in year_list:
     # a little more cleaning up
     df = df.dropna(axis=0, how='all') # drop rows with no good data
     df = df[df.time.notna()] # drop rows with bad time
+    df = df[df.z.notna()] # drop rows with missing depth
     df = df.reset_index(drop=True)
-    df['z'] = df['z']*-1 # IMPORTANT!!!!!! - from above!
+    df['z'] = df['z'] * -1 # IMPORTANT!!!!!! - from above!
+
+    # Keep rows where required state variables are available for TEOS-10 conversion.
+    if ('SP' in df.columns) and ('IT' in df.columns):
+        good = df['SP'].notna() & df['IT'].notna() & df['lat'].notna() & df['lon'].notna()
+        df = df.loc[good,:].copy()
+
+    if len(df) == 0:
+        print(' - processed 0 casts')
+        continue
+
     SP = df.SP.to_numpy()
     IT = df.IT.to_numpy()
-    z= df.z.to_numpy()
+    z = df.z.to_numpy()
     lon = df.lon.to_numpy()
     lat = df.lat.to_numpy()
     # do the gsw conversions
-    p = gsw.p_from_z(z, lat)    
+    p = gsw.p_from_z(z, lat)
     SA = gsw.SA_from_SP(SP, p, lon, lat)
     CT = gsw.CT_from_t(SA, IT, p)
-    # add the results to the dataframe
+    # add the results to the DataFrame
     df['SA'] = SA
     df['CT'] = CT
-    rho = gsw.rho(SA,CT,p)
+    rho = gsw.rho(SA, CT, p)
     # unit conversions
     if 'DO (mg -L)' in df.columns:
         df['DO (uM)'] = (1000/32) * df['DO (mg -L)']
@@ -137,15 +153,13 @@ for year in year_list:
         df['PO4 (uM)'] = (1000/30.973762) * df['PO4 (mg -L)']  # P atomic weight
     if 'Chl (ug -L)' in df.columns:
         df['Chl (mg m-3)'] = df['Chl (ug -L)']
-    for vn in ['TA','DIC']:
-        if (vn+' (umol -kg)') in df.columns:
-            df[vn+' (uM)'] = (rho/1000) * df[vn+' (umol -kg)']
+
     # retain only selected variables
     df['cruise'] = ''
     cols = ['cid', 'time', 'lat', 'lon', 'z', 'cruise', 'name',
         'CT', 'SA', 'DO (uM)',
-        'NO3 (uM)', 'NH4 (uM)', 'PO4 (uM)', 'SiO4 (uM)', #removed NO2...
-        'TA (uM)', 'DIC (uM)', 'Chl (mg m-3)']
+        'NO3 (uM)', 'NH4 (uM)', 'PO4 (uM)', 'SiO4 (uM)',
+        'Chl (mg m-3)']
     this_cols = [item for item in cols if item in df.columns]
     df = df[this_cols]
     # save

--- a/obs/kc_whidbeyBasin/process_bottle.py
+++ b/obs/kc_whidbeyBasin/process_bottle.py
@@ -33,7 +33,7 @@ out_dir = Ldir['LOo'] / 'obs' / source / otype
 Lfun.make_dir(out_dir)
 
 # Load big data set and stations.
-big_df_raw = pd.read_csv(in_dir0 / 'Whidbey_Bottle_Data_20260421.csv')
+big_df_raw = pd.read_csv(in_dir0 / 'Whidbey_Bottle_Data_20260421.csv', low_memory=False)
 sta_df = pd.read_csv(Ldir['data'] / 'obs' / source / 'WLRD_Sites_20260421.csv')
 
 # Merge station data.

--- a/obs/kc_whidbeyBasin/process_ctd.py
+++ b/obs/kc_whidbeyBasin/process_ctd.py
@@ -33,7 +33,7 @@ out_dir = Ldir['LOo'] / 'obs' / source / otype
 Lfun.make_dir(out_dir)
 
 # Load big data set and stations.
-big_df_raw = pd.read_csv(in_dir0/ 'Whidbey_Basin_CTD_Casts_20260420.csv') # updated 20260421
+big_df_raw = pd.read_csv(in_dir0/ 'Whidbey_Basin_CTD_Casts_20260420.csv', low_memory=False) # updated 20260421
 sta_df = pd.read_csv(Ldir['data'] / 'obs' / source / 'WLRD_Sites_20260421.csv')
 
 # Merge station data.

--- a/obs/kc_whidbeyBasin/process_ctd.py
+++ b/obs/kc_whidbeyBasin/process_ctd.py
@@ -9,9 +9,9 @@ Initial author date: 2024/04/04
 
 Finalized for public use: 2025/09/05
 
-Last updated: 2025/11/24 to correct conversion unit error for nitrogen species
-
 Written by: Dakota Mascarenas
+
+Most recent update: 2026/04/13
 
 """
 
@@ -33,7 +33,7 @@ out_dir = Ldir['LOo'] / 'obs' / source / otype
 Lfun.make_dir(out_dir)
 
 # Load big data set and stations.
-big_df_raw = pd.read_csv(in_dir0/ 'Whidbey_Basin_CTD_Casts_April2024.csv', low_memory=False)
+big_df_raw = pd.read_csv(in_dir0/ 'Whidbey_Basin_CTD_Casts_April2024.csv')
 sta_df = pd.read_csv(in_dir0 / 'WLRD_Sites_March2024.csv')
 
 # Merge station data.
@@ -58,6 +58,8 @@ v_list = np.array(list(v_dict_use.keys())) #redundant but fine
 # Clean column names.
 big_df_use6 = big_df_use0.copy()
 big_df_use6['time'] = pd.DatetimeIndex(big_df_use6['Sample Date'])
+# Convert from PST (UTC-8, no daylight savings adjustment) to UTC.
+big_df_use6['time'] = big_df_use6['time'].dt.tz_localize('Etc/GMT+8').dt.tz_convert('UTC')
 
 # Create unique cast IDs (cid).
 big_df_use6['cid'] = np.nan
@@ -113,7 +115,7 @@ for year in year_list:
     if 'DO (mg -L)' in df.columns:
         df['DO (uM)'] = (1000/32) * df['DO (mg -L)']
     if 'NO3 (mg -L)' in df.columns:
-        df['NO3 (uM)'] = (1000/14) * df['NO3 (mg -L)']
+        df['NO3 (uM)'] = (1000/62) * df['NO3 (mg -L)']
     if 'Chl (ug -L)' in df.columns:
         df['Chl (mg m-3)'] = df['Chl (ug -L)']
     # retain only selected variables             

--- a/obs/kc_whidbeyBasin/process_ctd.py
+++ b/obs/kc_whidbeyBasin/process_ctd.py
@@ -11,7 +11,7 @@ Finalized for public use: 2025/09/05
 
 Written by: Dakota Mascarenas
 
-Most recent update: 2026/04/13
+Most recent update: 2026/04/21
 
 """
 
@@ -33,8 +33,8 @@ out_dir = Ldir['LOo'] / 'obs' / source / otype
 Lfun.make_dir(out_dir)
 
 # Load big data set and stations.
-big_df_raw = pd.read_csv(in_dir0/ 'Whidbey_Basin_CTD_Casts_April2024.csv')
-sta_df = pd.read_csv(in_dir0 / 'WLRD_Sites_March2024.csv')
+big_df_raw = pd.read_csv(in_dir0/ 'Whidbey_Basin_CTD_Casts_20260420.csv') # updated 20260421
+sta_df = pd.read_csv(Ldir['data'] / 'obs' / source / 'WLRD_Sites_20260421.csv')
 
 # Merge station data.
 big_df = big_df_raw.merge(sta_df[['Locator','Latitude', 'Longitude']], on = 'Locator', how='left')
@@ -57,7 +57,7 @@ v_list = np.array(list(v_dict_use.keys())) #redundant but fine
         
 # Clean column names.
 big_df_use6 = big_df_use0.copy()
-big_df_use6['time'] = pd.DatetimeIndex(big_df_use6['Sample Date'])
+big_df_use6['time'] = pd.to_datetime(big_df_use6['Sample Date'], infer_datetime_format=True)
 # Convert from PST (UTC-8, no daylight savings adjustment) to UTC.
 big_df_use6['time'] = big_df_use6['time'].dt.tz_localize('Etc/GMT+8').dt.tz_convert('UTC')
 
@@ -115,7 +115,7 @@ for year in year_list:
     if 'DO (mg -L)' in df.columns:
         df['DO (uM)'] = (1000/32) * df['DO (mg -L)']
     if 'NO3 (mg -L)' in df.columns:
-        df['NO3 (uM)'] = (1000/62) * df['NO3 (mg -L)']
+        df['NO3 (uM)'] = (1000/14) * df['NO3 (mg -L)']  # N atomic weight
     if 'Chl (ug -L)' in df.columns:
         df['Chl (mg m-3)'] = df['Chl (ug -L)']
     # retain only selected variables             

--- a/obs/kc_whidbeyBasin/process_ctd.py
+++ b/obs/kc_whidbeyBasin/process_ctd.py
@@ -26,7 +26,7 @@ Ldir = Lfun.Lstart()
 source = 'kc_whidbeyBasin'
 otype = 'ctd'
 in_dir0 = Ldir['data'] / 'obs' / source / otype
-year_list = range(2022,2025)
+year_list = range(2022,2027)
 
 # output location
 out_dir = Ldir['LOo'] / 'obs' / source / otype

--- a/obs/pcRaft/README.md
+++ b/obs/pcRaft/README.md
@@ -1,0 +1,35 @@
+# README for pcRaft
+
+Author: Dakota Mascarenas
+
+Last updated: 2026/04/13
+
+These files are Penn Cove mussel raft sonde data from the work conducted and discussed in, or adjacent to, Roberts & Carrington (2023): https://doi.org/10.1016/j.jembe.2023.151927
+
+Data received via email on 2026/01/02 and 2026/02/24 from Emily Carrington to Dakota Mascarenas, with metadata clarification also on 2026/02/24.
+
+Location: 48.220861°N, 122.705667°W
+
+Two stations are processed:
+* `raft_main`: Primary YSI sonde data from 2014-2019 (hourly). Variables: temperature, salinity, chlorophyll, pH, DO. Source file: `PennCove-mussel-raft-sonde-data-2014-2019.xlsx` (sheet: `cleaned_data`).
+* `raft_hiRes`: July-December 2017 high-resolution HOBO temperature sondes at 0.5-7 m depth (originally 10-minute resolution, resampled to hourly). Source files: `B8_[depth]m.csv`. Temperature only — salinity is not directly measured.
+
+NOTE: Data type is `moor` (mooring format) despite being measured by YSI sondes.
+
+NOTE: Original timestamps are in PST (UTC-8); converted to UTC during processing.
+
+NOTE: `raft_hiRes` does not have directly measured salinity associated with temperature values. CT is computed using salinity interpolated from `raft_main` at the nearest time and depth using the GSW toolbox.
+
+NOTE: GSW conversions applied are from practical salinity (SP) to absolute salinity (SA) and in-situ temperature to conservative temperature (CT) using the `gsw` library.
+
+NOTE: DO converted from mg/L to uM (x1000/32). Chl are in ug/L = mg/m3.
+
+Mooring data availability (`raft_main`):
+* CT: 2014-2019
+* SA: 2014-2019
+* DO: 2014-2019
+* PH: 2014-2019
+* Chl: 2014-2019
+
+Mooring data availability (`raft_hiRes`):
+* CT: 2017

--- a/obs/pcRaft/evaluate_by_year.py
+++ b/obs/pcRaft/evaluate_by_year.py
@@ -1,0 +1,241 @@
+"""
+Evaluation plotting script for Penn Cove mussel raft sonde data.
+
+Produces two figure types per station per year:
+  1. Heatmap (time × depth) — overview of the full record.
+  2. Time series (one line per depth) — fine-grained inspection per variable.
+
+Usage: set `year` at the top and run.  Set year = None to loop all years.
+
+Finalized for public use: 2026/04/13
+
+Author: Dakota Mascarenas
+"""
+
+# %%
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+import matplotlib.pyplot as plt
+import matplotlib.dates as mdates
+from lo_tools import Lfun
+
+Ldir = Lfun.Lstart()
+
+# ---- USER SETTINGS -------------------------------------------------------
+year = None   # int (e.g. 2016) or None to loop through all available years
+
+# Optional y-axis zoom per variable (overrides vmin/vmax for display only).
+# Set to None to use the default range from var_meta.
+# Example: {'CT': (8, 14), 'SA': (28, 32)}
+ylim_override = {
+    'CT':           None,
+    'SA':           None,
+    'DO (uM)':      (0, 600),
+    'PH':           (7.2, 8.8),
+    'Chl (mg m-3)': (0, 300),
+}
+# --------------------------------------------------------------------------
+
+source = 'pcRaft'
+otype  = 'moor'
+in_dir = Ldir['LOo'] / 'obs' / source / otype
+
+plot_dir = Ldir['LOo'] / 'obs' / source / 'eval_plots'
+Lfun.make_dir(plot_dir)
+
+# Variable display metadata: name -> (colormap, (vmin, vmax), label)
+var_meta = {
+    'CT':          ('RdYlBu_r', (0, 25),    'Cons. Temp. (°C)'),
+    'SA':          ('viridis',  (0, 33),   'Abs. Salinity (g kg⁻¹)'),
+    'DO (uM)':     ('YlGnBu',  (0, 600),   'DO (μM)'),
+    'PH':          ('PiYG',     (7.2, 8.8), 'pH'),
+    'Chl (mg m-3)':('YlGn',    (0, 300),    'Chl (mg m⁻³)'),
+}
+
+stations = ['raft_main', 'raft_hiRes']
+
+# %%
+
+def plot_year(ds, station, yr, plot_dir):
+    """
+    Create a heatmap figure (time × depth) for each variable in ds,
+    restricted to the given year.  Saves one PNG per station per year.
+    """
+
+    # Slice to the requested year
+    time_idx = pd.DatetimeIndex(ds['time'].values)
+    mask = time_idx.year == yr
+    if mask.sum() == 0:
+        print(f'  No data for {station} in {yr}, skipping.')
+        return
+
+    ds_yr = ds.isel(time=np.where(mask)[0])
+    time_vals = pd.DatetimeIndex(ds_yr['time'].values)
+    z_vals    = ds_yr['z'].values   # negative depths (e.g. -7 to -0.5)
+
+    avail_vars = [v for v in var_meta if v in ds_yr.data_vars]
+    n_vars = len(avail_vars)
+    if n_vars == 0:
+        print(f'  No plottable variables in {station} for {yr}.')
+        return
+
+    fig, axes = plt.subplots(n_vars, 1,
+                             figsize=(14, 3.5 * n_vars),
+                             sharex=True)
+    if n_vars == 1:
+        axes = [axes]
+
+    fig.suptitle(f'{station} — {yr}', fontsize=13, fontweight='bold')
+
+    for ax, vname in zip(axes, avail_vars):
+        cmap, (vmin, vmax), label = var_meta[vname]
+        # Apply display zoom if set
+        override = ylim_override.get(vname)
+        disp_min, disp_max = override if override is not None else (vmin, vmax)
+        data = ds_yr[vname].values   # shape (NT, NZ)
+
+        # pcolormesh needs grid edges; build them from centres
+        # time axis: use numeric values (matplotlib dates)
+        t_num  = mdates.date2num(time_vals.to_pydatetime())
+        dt     = np.diff(t_num)
+        dt     = np.append(dt, dt[-1])
+        t_edges = np.append(t_num - dt / 2, t_num[-1] + dt[-1] / 2)
+
+        dz      = np.diff(z_vals)
+        dz      = np.append(dz[0], dz)
+        z_edges = np.append(z_vals - np.abs(dz) / 2,
+                             z_vals[-1] + np.abs(dz[-1]) / 2)
+
+        # Use masked array so NaN shows as white
+        data_masked = np.ma.masked_invalid(data.T)   # (NZ, NT)
+
+        pcm = ax.pcolormesh(t_edges, z_edges, data_masked,
+                    cmap=cmap, vmin=disp_min, vmax=disp_max,
+                    shading='flat')
+
+        cb = fig.colorbar(pcm, ax=ax, pad=0.01, fraction=0.02)
+        cb.set_label(label, fontsize=8)
+
+        # Scatter any values outside the expected range so they stand out
+        out_mask = (~np.isnan(data)) & ((data < vmin) | (data > vmax))
+        if out_mask.any():
+            t_idx, z_idx = np.where(out_mask)
+            ax.scatter(t_num[t_idx], z_vals[z_idx],
+                       color='red', s=10, zorder=5,
+                       label=f'out-of-range ({out_mask.sum()})')
+            ax.legend(loc='upper right', fontsize=7)
+
+        ax.set_ylabel('Depth (m)', fontsize=9)
+        ax.set_title(label, fontsize=9)
+        ax.xaxis.set_major_formatter(mdates.DateFormatter('%b'))
+        ax.xaxis.set_major_locator(mdates.MonthLocator())
+        ax.grid(True, alpha=0.25, linestyle=':')
+
+    axes[-1].set_xlabel(f'{yr} (UTC)', fontsize=9)
+    plt.tight_layout()
+
+    out_fn = plot_dir / f'{station}_{yr}_heatmap.png'
+    plt.savefig(out_fn, dpi=150, bbox_inches='tight')
+    plt.close()
+    print(f'  Saved: {out_fn}')
+
+
+def plot_year_timeseries(ds, station, yr, plot_dir):
+    """
+    Create a time-series figure for each variable in ds, restricted to the
+    given year.  Each depth level is drawn as a separate line.  Values outside
+    the expected range are highlighted with red markers.
+    Saves one PNG per station per year.
+    """
+
+    time_idx = pd.DatetimeIndex(ds['time'].values)
+    mask = time_idx.year == yr
+    if mask.sum() == 0:
+        return  # already reported by plot_year
+
+    ds_yr = ds.isel(time=np.where(mask)[0])
+    time_vals = pd.DatetimeIndex(ds_yr['time'].values)
+    z_vals    = ds_yr['z'].values
+
+    avail_vars = [v for v in var_meta if v in ds_yr.data_vars]
+    n_vars = len(avail_vars)
+    if n_vars == 0:
+        return
+
+    # Use a colormap to assign one colour per depth level
+    depth_cmap = plt.get_cmap('plasma', max(len(z_vals), 1))
+
+    fig, axes = plt.subplots(n_vars, 1,
+                             figsize=(14, 3.5 * n_vars),
+                             sharex=True)
+    if n_vars == 1:
+        axes = [axes]
+
+    fig.suptitle(f'{station} — {yr} (time series)', fontsize=13, fontweight='bold')
+
+    for ax, vname in zip(axes, avail_vars):
+        _, (vmin, vmax), label = var_meta[vname]
+        # Apply display zoom if set
+        override = ylim_override.get(vname)
+        disp_min, disp_max = override if override is not None else (vmin, vmax)
+        data = ds_yr[vname].values   # shape (NT, NZ)
+
+        for z_idx, z in enumerate(z_vals):
+            col = depth_cmap(z_idx / max(len(z_vals) - 1, 1))
+            series = data[:, z_idx]
+            valid  = ~np.isnan(series)
+            if valid.sum() == 0:
+                continue
+            ax.plot(time_vals[valid], series[valid],
+                    color=col, linewidth=0.8, alpha=0.85,
+                    label=f'z={z:.1f} m')
+
+            # Highlight out-of-range points
+            out = valid & ((series < vmin) | (series > vmax))
+            if out.any():
+                ax.scatter(time_vals[out], series[out],
+                           color='red', s=14, zorder=5)
+
+        # Shaded band for expected range
+        ax.axhspan(vmin, vmax, color='lightgrey', alpha=0.15, zorder=0)
+        ax.set_ylim(disp_min, disp_max)
+        ax.set_ylabel(label, fontsize=9)
+        ax.set_title(label, fontsize=9)
+        ax.xaxis.set_major_formatter(mdates.DateFormatter('%b'))
+        ax.xaxis.set_major_locator(mdates.MonthLocator())
+        ax.grid(True, alpha=0.25, linestyle=':')
+        ax.legend(loc='upper right', fontsize=7, ncol=2)
+
+    axes[-1].set_xlabel(f'{yr} (UTC)', fontsize=9)
+    plt.tight_layout()
+
+    out_fn = plot_dir / f'{station}_{yr}_timeseries.png'
+    plt.savefig(out_fn, dpi=150, bbox_inches='tight')
+    plt.close()
+    print(f'  Saved: {out_fn}')
+
+
+# %%
+
+for sn in stations:
+    nc_path = in_dir / f'{sn}.nc'
+    if not nc_path.exists():
+        print(f'File not found: {nc_path}')
+        continue
+
+    ds = xr.open_dataset(nc_path)
+
+    all_years = sorted(set(pd.DatetimeIndex(ds['time'].values).year))
+    years_to_plot = [year] if year is not None else all_years
+
+    print(f'\n{sn}: available years = {all_years}')
+    for yr in years_to_plot:
+        print(f'  Plotting {yr}...')
+        plot_year(ds, sn, yr, plot_dir)
+        plot_year_timeseries(ds, sn, yr, plot_dir)
+
+    ds.close()
+
+print('\nDone.')

--- a/obs/pcRaft/process_moor.py
+++ b/obs/pcRaft/process_moor.py
@@ -1,0 +1,251 @@
+"""
+Code to process Penn Cove mussel raft sonde data as discussed in Roberts & Carrington (2023): https://doi.org/10.1016/j.jembe.2023.151927
+
+Data received via email on 2026/01/02 and 2026/02/24 from Emily Carrington to Dakota Mascarenas, with metadata clarification also on 2026/02/24.
+
+Initial author date: 2026/02/24
+
+Finalized for public use: 2026/04/13
+
+Written by: Dakota Mascarenas
+
+"""
+# %%
+
+import pandas as pd
+import numpy as np
+import gsw
+import xarray as xr
+
+from lo_tools import Lfun, obs_functions
+Ldir = Lfun.Lstart()
+
+# source location
+source = 'pcRaft'
+otype = 'moor'
+in_dir0 = Ldir['data'] / 'obs' / source
+year_list = range(2014,2020)
+
+# output locations for both output types
+out_dir = Ldir['LOo'] / 'obs' / source / otype 
+Lfun.make_dir(out_dir)
+
+sn_loc_dict = {
+    'raft_main': [-122.705667, 48.220861],
+    'raft_hiRes': [-122.705667, 48.220861],
+}
+
+
+# Load big data set and stations.
+big_df = pd.read_excel(in_dir0/ 'PennCove-mussel-raft-sonde-data-2014-2019.xlsx', sheet_name='cleaned_data')
+big_df['time'] = pd.DatetimeIndex(big_df['TIMESTAMP'])
+# Convert from PST (UTC-8) to UTC
+big_df['time'] = big_df['time'].dt.tz_localize('Etc/GMT+8').dt.tz_convert('UTC')
+big_df['station'] = 'raft_main'
+big_df = big_df[['station', 'time', 'depth', 'temp', 'sal', 'chl', 'pH', 'DO']]
+
+# Load in July-December 2017 high resolution sampling (10 minute frequency to be selected only on even hour marks).
+little_df = pd.DataFrame()
+for depth in [0.5, 1, 2, 3, 4, 5, 6, 7]:
+    little_df_temp = pd.read_csv(in_dir0/ ('B8_' + str(depth) + 'm.csv'))
+    little_df_temp['depth'] = depth
+    little_df_temp = little_df_temp.set_axis(['#', 'TIME', 'temp', 'depth'], axis=1)
+    little_df = pd.concat([little_df, little_df_temp])
+little_df['time'] = pd.DatetimeIndex(little_df['TIME'])
+# Convert from PST (UTC-8) to UTC
+little_df['time'] = little_df['time'].dt.tz_localize('Etc/GMT+8').dt.tz_convert('UTC')
+little_df = little_df[['time', 'depth', 'temp']]
+little_df = (
+    little_df
+    .set_index('time')
+    .groupby('depth')['temp']
+    .resample('1h')
+    .mean(numeric_only=True)
+    .reset_index()
+)
+little_df['station'] = 'raft_hiRes'
+
+# %%
+
+# Combine dataframes.
+big_df_use = pd.concat([big_df, little_df])
+
+# Create dictionary for important variable and column names.
+v_dict = {'chl':'Chl (ug -L)',
+          'DO':'DO (mg -L)',
+          'pH':'PH',
+          'sal':'SP', 
+          'temp':'IT' 
+          }
+v_dict_use = {}
+for v in v_dict.keys():
+    if len(v_dict[v]) > 0:
+        v_dict_use[v] = v_dict[v]
+v_list = np.array(list(v_dict_use.keys())) #redundant but fine
+        
+# Clean column names and add coordinates.
+df0 = big_df_use.copy()
+    
+
+# Rename some columns in variable dictionary.
+v_dict['time'] = 'time'
+v_dict['depth'] = 'z' # will be converted to negative later in script
+# %%
+# Loop through to rename variables and columns, clean the dataset, and produce output dataframes.
+
+for sn in ['raft_main', 'raft_hiRes']:
+    out_fn = out_dir / (sn + '.nc')
+    df1 = df0[df0['station'] == sn].copy()
+    df = pd.DataFrame()
+    for v in df1.columns:
+        if v in v_dict.keys():
+            if len(v_dict[v]) > 0:
+                df[v_dict[v]] = df1[v]
+    # a little more cleaning up
+    df = df.dropna(axis=0, how='all') # drop rows with no good data
+    df = df[df.time.notna()] # drop rows with bad time
+    df = df.reset_index(drop=True)
+    df['z'] = df['z']*-1 # IMPORTANT!!!!!! - from above!
+    df['lon'] = sn_loc_dict[sn][0]
+    df['lat'] = sn_loc_dict[sn][1]
+    IT = df.IT.to_numpy()
+    z= df.z.to_numpy()
+    lon = df.lon.to_numpy()
+    lat = df.lat.to_numpy()
+    if sn == 'raft_main':
+        SP = df.SP.to_numpy()
+        # do the gsw conversions
+        p = gsw.p_from_z(z, lat)
+        SA = gsw.SA_from_SP(SP, p, lon, lat)
+        CT = gsw.CT_from_t(SA, IT, p)
+        # add the results to the DataFrame
+        df['SA'] = SA
+        df['CT'] = CT
+    elif sn == 'raft_hiRes':
+        # For each depth in raft_hiRes, find the closest depth in raft_main and use its salinity
+        df_main = df0[df0['station'] == 'raft_main'].copy()
+        # Rename depth to z to match the processed dataframe
+        df_main['z'] = df_main['depth'] * -1
+        # Remove timezone info for comparison (times are already in UTC)
+        df_main['time'] = df_main['time'].dt.tz_localize(None)
+        df['time'] = df['time'].dt.tz_localize(None)
+        SP = np.zeros_like(IT)
+        
+        for idx, (time_val, depth_val) in enumerate(zip(df['time'].values, z)):
+            # Find matching time in raft_main data
+            main_time_match = df_main[df_main['time'] == time_val]
+            
+            if len(main_time_match) > 0:
+                # Find closest depth in raft_main for this time
+                available_depths = main_time_match['z'].values
+                closest_depth_idx = np.argmin(np.abs(available_depths - depth_val))
+                SP[idx] = main_time_match.iloc[closest_depth_idx]['sal']
+            else:
+                # If no exact time match, interpolate from nearest time
+                time_diff = np.abs(df_main['time'].values - time_val)
+                nearest_time_idx = np.argmin(time_diff)
+                nearest_time = df_main.iloc[nearest_time_idx]['time']
+                
+                # Find closest depth at that time
+                main_at_time = df_main[df_main['time'] == nearest_time]
+                available_depths = main_at_time['z'].values
+                closest_depth_idx = np.argmin(np.abs(available_depths - depth_val))
+                SP[idx] = main_at_time.iloc[closest_depth_idx]['sal']
+        
+        # do the gsw conversions using matched SP data
+        p = gsw.p_from_z(z, lat)
+        SA = gsw.SA_from_SP(SP, p, lon, lat)
+        CT = gsw.CT_from_t(SA, IT, p)
+        # add the results to the DataFrame
+        df['SA'] = np.nan # set SA to NaN since it's not directly measured in raft_hiRes
+        df['CT'] = CT
+
+    # unit conversions
+    if 'DO (mg -L)' in df.columns:
+        df['DO (uM)'] = (1000/32) * df['DO (mg -L)']
+    if 'NO3 (mg -L)' in df.columns:
+        df['NO3 (uM)'] = (1000/62) * df['NO3 (mg -L)']
+    if 'Chl (ug -L)' in df.columns:
+        df['Chl (mg m-3)'] = df['Chl (ug -L)']
+    
+    # retain only selected variables
+    cols = ['time', 'lat', 'lon', 'z',
+        'SA', 'CT', 'DO (uM)',
+        'PH', 'Chl (mg m-3)']
+    
+    # Select and filter columns that exist in the dataframe
+    this_cols = [item for item in cols if item in df.columns]
+    df = df[this_cols]
+    
+    # Remove duplicate records
+    if 'z' in df.columns:
+        df = df[~df.duplicated(subset=["time", "z"], keep=False)]
+    
+    # Save to NetCDF in correct format (hourly)
+    if len(df) > 0:
+        print(f'Processing {sn}: {len(df)} records')
+        
+        # Convert to numpy arrays for xarray Dataset creation
+        time_arr = df['time'].unique()
+        # Remove timezone info for NetCDF compatibility (times are already in UTC)
+        time_arr = pd.DatetimeIndex(time_arr).tz_localize(None)
+        z_arr = np.sort(df['z'].unique())
+        NT = len(time_arr)
+        NZ = len(z_arr)
+        
+        # Create a 2D array for each variable (time, z)
+        def create_2d_array(var_name):
+            """Create 2D array (time, z) from dataframe"""
+            arr = np.full((NT, NZ), np.nan)
+            # Remove timezone for matching
+            df_time_naive = df.copy()
+            df_time_naive['time'] = df_time_naive['time'].dt.tz_localize(None)
+            for t_idx, t in enumerate(time_arr):
+                time_data = df_time_naive[df_time_naive['time'] == t]
+                for z_idx, z in enumerate(z_arr):
+                    match = time_data[time_data['z'] == z]
+                    if len(match) > 0:
+                        arr[t_idx, z_idx] = match[var_name].values[0]
+            return arr
+        
+        # Create coordinate arrays
+        coords = {'time': ('time', time_arr), 'z': ('z', z_arr)}
+        
+        # Create data_vars dict with variables that exist
+        data_vars = {}
+        data_vars['CT'] = (('time', 'z'), create_2d_array('CT'))
+        
+        if 'SA' in df.columns:
+            data_vars['SA'] = (('time', 'z'), create_2d_array('SA'))
+        if 'DO (uM)' in df.columns:
+            data_vars['DO (uM)'] = (('time', 'z'), create_2d_array('DO (uM)'))
+        if 'PH' in df.columns:
+            data_vars['PH'] = (('time', 'z'), create_2d_array('PH'))
+        if 'Chl (mg m-3)' in df.columns:
+            data_vars['Chl (mg m-3)'] = (('time', 'z'), create_2d_array('Chl (mg m-3)'))
+        
+        # Create Dataset in correct format
+        lon = float(df['lon'].iloc[0])
+        lat = float(df['lat'].iloc[0])
+        ds = xr.Dataset(coords=coords, 
+                       attrs={'Station Name': sn, 'lon': lon, 'lat': lat})
+        
+        # Add variables with attributes
+        for var_name, (dims, data) in data_vars.items():
+            ds[var_name] = xr.DataArray(data, dims=dims)
+        
+        # Set variable attributes
+        ds['CT'].attrs = {'units': 'degC', 'long_name': 'Conservative Temperature'}
+        if 'SA' in ds.data_vars:
+            ds['SA'].attrs = {'units': 'g kg-1', 'long_name': 'Absolute Salinity'}
+        if 'DO (uM)' in ds.data_vars:
+            ds['DO (uM)'].attrs = {'units': 'uM', 'long_name': 'Dissolved Oxygen'}
+        if 'PH' in ds.data_vars:
+            ds['PH'].attrs = {'units': 'NBS scale', 'long_name': 'pH'}
+        if 'Chl (mg m-3)' in ds.data_vars:
+            ds['Chl (mg m-3)'].attrs = {'units': 'mg m-3', 'long_name': 'Chlorophyll'}
+        
+        ds.to_netcdf(out_fn)
+        ds.close()
+        print(f'  Saved to: {out_fn}')
+    


### PR DESCRIPTION
Two categories of changes to obs/:

Timezone-aware UTC handling — Updated processing scripts for ecology_his, kc, kc_his, kc_pointJefferson, and kc_whidbeyBasin to produce timezone-aware UTC timestamps. Added explicit PST→UTC conversions where applicable. Added timezone documentation notes to each source's README.

New obs source: pcRaft — Penn Cove mussel raft sonde data (mooring format) from Roberts & Carrington (2023). Includes process_moor.py for two stations (raft_main 2014–2019 hourly YSI data; raft_hiRes July–Dec 2017 HOBO temperature sondes) and evaluate_by_year.py for visualization.

Minor: removed low_memory=False from pd.read_csv calls.